### PR TITLE
feat: add subdomains for iccv 2025 workshops

### DIFF
--- a/terraform/prod/main.tf
+++ b/terraform/prod/main.tf
@@ -54,4 +54,23 @@ resource "aws_route53_record" "sub_domain" {
   }
 }
 
+
+resource "aws_route53_record" "iccv2025_found_workshop_domain" {
+  zone_id = data.aws_route53_zone.host_domain.zone_id
+  name    = "iccv2025-found-workshop.${var.domain_name}"
+  type    = "CNAME"
+  ttl     = 300
+  records = ["${var.github_username}.github.io"]
+}
+
+
+resource "aws_route53_record" "iccv2025_limit_workshop_domain" {
+  zone_id = data.aws_route53_zone.host_domain.zone_id
+  name    = "iccv2025-limit-workshop.${var.domain_name}"
+  type    = "CNAME"
+  ttl     = 300
+  records = ["${var.github_username}.github.io"]
+}
+
+
 output "cloudfront_domain_name" { value = module.s3_cloudfront.cloudfront_domain_name }

--- a/terraform/prod/variables.tf
+++ b/terraform/prod/variables.tf
@@ -20,3 +20,10 @@ variable "project_name" {
   description = "The name of the project."
   default     = "limitlab-webpage"
 }
+
+
+variable "github_username" {
+  type        = string
+  description = "The GitHub username."
+  default     = "cvpaperchallenge"
+}


### PR DESCRIPTION
## Issue URL

NA

## Change overview

- Add "iccv2025-found-workshop.limitlab.xyz" record for FOUND Workshop in ICCV 2025
- Add "iccv2025-limit-workshop.limitlab.xyz" record for LIMIT Workshop in ICCV 2025

## How to test

You can follow "Deploy prod resources" section of `terraform/README.md` and check there is no error with `terraform plan`

## Note for reviewers

NA