### PR TITLE
fix: make trailingSlash option is true

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,7 @@ const nextConfig = {
   devIndicators: {
     appIsrStatus: false,
   },
+  trailingSlash: true,
 }
 
 export default nextConfig


### PR DESCRIPTION
This pull request introduces a small configuration update to the `next.config.ts` file. The change enables the `trailingSlash` option in the Next.js configuration.

* [`next.config.ts`](diffhunk://#diff-e3f38f2f0e7ba92f0dd56c086ec5de704229d58d5371e8cc57e43961757d8c7bR8): Added the `trailingSlash` property and set it to `true`, ensuring that URLs will include a trailing slash. without this option CloudFront might cause 404 error.