### PR TITLE
Add separate build and deploy jobs

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,50 @@
+name: deploy
+
+on:
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Build webpage in Docker container
+        run: |
+          cd environments
+          docker compose build frontend
+          docker compose run --rm frontend bash -lc "yarn install --frozen-lockfile && yarn build"
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: out
+          path: out
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: out
+          path: out
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Sync built files to S3
+        run: aws s3 sync out s3://${{ secrets.S3_BUCKET_NAME }} --delete

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,15 +1,23 @@
-name: deploy
-
+name: deploy-to-s3
+permissions:
+  contents: read
+  actions: read
+  pages: write
+  id-token: write
 on:
   workflow_dispatch:
-
 defaults:
   run:
     shell: bash
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -21,29 +29,30 @@ jobs:
           docker compose run --rm frontend bash -lc "yarn install --frozen-lockfile && yarn build"
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
-          name: out
-          path: out
+          name: build
+          path: out/
 
   deploy:
-    needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: build
+
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
 
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
-          name: out
+          name: build
           path: out
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Sync built files to S3

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,22 +17,44 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      DOCKER_COMPOSE_DIRECTORY: environments
     
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Build webpage in Docker container
+      - name: Check version info
+        run: pwd && docker compose version && docker --version
+
+      - name: Get UID/GID of the runner
+        id: get_uid_gid
         run: |
-          cd environments
-          docker compose build frontend
-          docker compose run --rm frontend bash -lc "yarn install --frozen-lockfile && yarn build"
+          echo "HOST_UID=$(id -u)" >> $GITHUB_ENV
+          echo "HOST_GID=$(id -g)" >> $GITHUB_ENV
+
+      - name: Create and start docker container
+        run: docker compose up -d
+        working-directory: ${{ env.DOCKER_COMPOSE_DIRECTORY }}
+
+      - name: Install dependencies in Docker container
+        working-directory: ${{ env.DOCKER_COMPOSE_DIRECTORY }}
+        run: docker compose exec -T frontend yarn install --frozen-lockfile
+
+      - name: Build webpage in Docker container
+        working-directory: ${{ env.DOCKER_COMPOSE_DIRECTORY }}
+        run: docker compose exec -T frontend yarn build
+
+      - name: Stop container
+        if: always()
+        run: docker compose down
+        working-directory: ${{ env.DOCKER_COMPOSE_DIRECTORY }}
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v3
         with:
-          name: build
-          path: out/
+          name: built-webpage
+          path: ./out
 
   deploy:
     runs-on: ubuntu-latest
@@ -46,8 +68,8 @@ jobs:
       - name: Download build artifact
         uses: actions/download-artifact@v3
         with:
-          name: build
-          path: out
+          name: built-webpage
+          path: ./out
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
## Summary
- update deploy workflow to separate build and deploy steps into distinct jobs

## Testing
- `npm ci` *(fails: Exit handler never called)*
- `npm run lint-check` *(fails: cannot find package `@eslint/js`)*
- `npm run build` *(fails: `next` not found)*
