### PR TITLE
feat: add oidc for github actions

### DIFF
--- a/terraform/prod/backend.tf
+++ b/terraform/prod/backend.tf
@@ -12,6 +12,11 @@ terraform {
       source  = "hashicorp/aws"
       version = "5.82.2"
     }
+
+    tls = {
+      source  = "hashicorp/tls"
+      version = "4.1.0"
+    }
   }
 
   required_version = "= 1.10.3"

--- a/terraform/prod/github_actions_role.tf
+++ b/terraform/prod/github_actions_role.tf
@@ -1,0 +1,37 @@
+resource "aws_iam_role" "github_actions" {
+  name = "github-actions-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Federated = aws_iam_openid_connect_provider.github_actions.arn }
+      Action    = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringEquals = {
+          "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          "token.actions.githubusercontent.com:sub" = "repo:${var.github_repo}:*"
+        }
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "s3_sync_policy" {
+  name = "s3-sync-policy"
+  role = aws_iam_role.github_actions.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["s3:ListBucket", "s3:GetBucketLocation"]
+        Resource = ["arn:aws:s3:::${local.bucket_name}"]
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+        Resource = ["arn:aws:s3:::${local.bucket_name}/*"]
+      }
+    ]
+  })
+}

--- a/terraform/prod/oidc_provider.tf
+++ b/terraform/prod/oidc_provider.tf
@@ -1,0 +1,12 @@
+# TLS certificate data source to retrieve the thumbprint for GitHub Actions OIDC.
+# ref: https://zenn.dev/nameless_gyoza/articles/github-actions-aws-oidc-by-terraform
+data "tls_certificate" "github_actions" {
+  url = "https://token.actions.githubusercontent.com/.well-known/openid-configuration"
+}
+
+# OIDC provider for GitHub Actions to access AWS resources.
+resource "aws_iam_openid_connect_provider" "github_actions" {
+  url            = "https://token.actions.githubusercontent.com"
+  client_id_list = ["sts.amazonaws.com"]
+  thumbprint_list = [data.tls_certificate.github_actions.certificates[0].sha1_fingerprint]
+}

--- a/terraform/prod/variables.tf
+++ b/terraform/prod/variables.tf
@@ -27,3 +27,9 @@ variable "github_username" {
   description = "The GitHub username."
   default     = "cvpaperchallenge"
 }
+
+variable "github_repo" {
+  type        = string
+  description = "The name of the GitHub repository."
+  default     = "cvpaperchallenge-alumni/limit-lab-homepage" 
+}


### PR DESCRIPTION
This pull request introduces changes to the Terraform configuration to enable integration between GitHub Actions and AWS resources. It adds support for GitHub Actions OIDC authentication, defines IAM roles and policies for S3 access, and updates variables for repository-specific configurations.

### Integration with GitHub Actions:

* **Added TLS module for OIDC provider setup**: Introduced the `tls` module in `terraform/prod/backend.tf` to manage TLS certificate data for GitHub Actions OIDC authentication.
* **Defined OIDC provider for GitHub Actions**: Created an OIDC provider using the `aws_iam_openid_connect_provider` resource to allow GitHub Actions to authenticate with AWS. This includes fetching the TLS certificate thumbprint.

### IAM Role and Policies for S3 Access:

* **Created IAM role for GitHub Actions**: Added an `aws_iam_role` resource named `github-actions-role` with a policy allowing GitHub Actions to assume the role via OIDC.
* **Added IAM policy for S3 synchronization**: Defined an `aws_iam_role_policy` resource to grant permissions for GitHub Actions to list, get, put, and delete objects in a specified S3 bucket.

### Repository-specific Configuration:

* **Introduced `github_repo` variable**: Added a new variable in `terraform/prod/variables.tf` to specify the GitHub repository name for use in IAM role policies.
## Issue URL