### PR TITLE
fix: use v4 instead of v3.

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -51,9 +51,9 @@ jobs:
         working-directory: ${{ env.DOCKER_COMPOSE_DIRECTORY }}
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: built-webpage
+          name: built-artifact
           path: ./out
 
   deploy:
@@ -66,9 +66,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download build artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: built-webpage
+          name: built-artifact
           path: ./out
 
       - name: Configure AWS credentials


### PR DESCRIPTION
This pull request updates the `.github/workflows/deploy.yaml` file to use the latest versions of GitHub Actions for artifact handling and adjusts artifact naming for clarity.

Updates to GitHub Actions versions:

* Updated `actions/upload-artifact` from version `v3` to `v4` in the `Upload build artifact` step.
* Updated `actions/download-artifact` from version `v3` to `v4` in the `Download build artifact` step.

Changes to artifact naming:

* Renamed the artifact from `built-webpage` to `built-artifact` in both upload and download steps for consistency and clarity. [[1]](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L54-R56) [[2]](diffhunk://#diff-4f9e38227ed64fefb17f4668a7ac4ab55b6149994d5ac2fd96182d5958479b54L69-R71)