### PR TITLE
Fix IAM role trust for GitHub Actions

### DIFF
--- a/terraform/prod/github_actions_role.tf
+++ b/terraform/prod/github_actions_role.tf
@@ -9,6 +9,8 @@ resource "aws_iam_role" "github_actions" {
       Condition = {
         StringEquals = {
           "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+        }
+        StringLike = {
           "token.actions.githubusercontent.com:sub" = "repo:${var.github_repo}:*"
         }
       }


### PR DESCRIPTION
## Summary
- update trust policy to match OIDC subjects using `StringLike`

## Testing
- `npm run lint-check` *(fails: Cannot find package 'globals')*
- `terraform fmt terraform/` *(fails: command not found)*
- `terraform validate terraform/` *(fails: command not found)*
- `tflint --init` *(fails: command not found)*
- `tflint --chdir=terraform/ --recursive` *(fails: command not found)*