### PR TITLE
chore: hide contanct from mobile ui

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -46,7 +46,7 @@ export function Header() {
   useEffect(() => {
     if (pathname === '/') setPage('top')
     else if (pathname.startsWith('/publications')) setPage('publication')
-    else if (pathname.startsWith('/contact')) setPage('contact')
+    // else if (pathname.startsWith('/contact')) setPage('contact')
   }, [pathname])
 
   useEffect(() => {
@@ -229,13 +229,13 @@ export function Header() {
                   >
                     Publications
                   </DropdownMenuRadioItem>
-                  <DropdownMenuRadioItem
+                  {/* <DropdownMenuRadioItem
                     value="contact"
                     isDarkMode={isDarkMode}
                     onClick={() => router.push('/contact')}
                   >
                     Contact
-                  </DropdownMenuRadioItem>
+                  </DropdownMenuRadioItem> */}
                 </DropdownMenuRadioGroup>
               </DropdownMenuContent>
             </DropdownMenu>


### PR DESCRIPTION
This pull request includes minor changes to the `Header` component in `src/components/header.tsx`. The changes comment out code related to the "Contact" page, effectively removing its functionality from the component.

Changes to the `Header` component:

* Commented out the logic in the `useEffect` hook that sets the page to "contact" when the pathname starts with `/contact`.
* Commented out the "Contact" option in the dropdown menu, preventing users from navigating to the "Contact" page via the UI.