### PR TITLE
Update member affiliations

### DIFF
--- a/src/data/topPageData.ts
+++ b/src/data/topPageData.ts
@@ -59,7 +59,7 @@ export const members = [
   },
   {
     name: 'Nakamasa Inoue',
-    affiliation: '',
+    affiliation: 'Science Tokyo',
     photoUrl: '/members/nakamasa.inoue-256x256.jpg',
     githubUrl: '',
     XUrl: '',
@@ -67,7 +67,7 @@ export const members = [
   },
   {
     name: 'Go Irie',
-    affiliation: '',
+    affiliation: 'TUS',
     photoUrl: '/members/go.irie-256x256.jpg',
     githubUrl: '',
     XUrl: '',
@@ -75,7 +75,7 @@ export const members = [
   },
   {
     name: 'Rio Yokota',
-    affiliation: '',
+    affiliation: 'Science Tokyo',
     photoUrl: '/members/rio.yokota-256x256.jpg',
     githubUrl: '',
     XUrl: '',
@@ -83,7 +83,7 @@ export const members = [
   },
   {
     name: 'Ikuro Sato',
-    affiliation: '',
+    affiliation: 'Science Tokyo',
     photoUrl: '/members/ikuro.sato-256x256.jpg',
     githubUrl: '',
     XUrl: '',
@@ -91,7 +91,7 @@ export const members = [
   },
   {
     name: 'Rei Kawakami',
-    affiliation: '',
+    affiliation: 'Science Tokyo',
     photoUrl: '/members/rei.kawakami-256x256.jpg',
     githubUrl: '',
     XUrl: '',


### PR DESCRIPTION
## Summary
- update affiliation for Go Irie
- add Science Tokyo affiliation for Nakamasa Inoue, Rio Yokota, Ikuro Sato and Rei Kawakami

## Testing
- `npm run lint-check` *(fails: Cannot find package 'globals')*
- `npm run format-check` *(fails: Cannot find package 'prettier-plugin-tailwindcss')*

------
https://chatgpt.com/codex/tasks/task_e_683f2fb41fa883269366f387fc6de1bc