### PR TITLE
Add Cambridge CV workshop to recent news

### DIFF
--- a/src/data/topPageData.ts
+++ b/src/data/topPageData.ts
@@ -1,6 +1,11 @@
 // Sample data for recent news
 export const newsItems = [
   {
+    date: '2025-09-26',
+    description: 'We jointly hosted the Cambridge Computer Vision Workshop.',
+    url: 'https://cambridgecv-workshop-2025sep.limitlab.xyz/',
+  },
+  {
     date: '2025-07-14',
     description: 'Ryousuke Yamada appointed JSPS research fellow at FunAI Lab.',
     url: 'https://fundamentalailab.github.io/',


### PR DESCRIPTION
## Summary
- add a September 26, 2025 news item for the jointly hosted Cambridge Computer Vision Workshop

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d445a215fc8326ac513bbfe9bdb35a