### PR TITLE
feat: support inline links in news content

### DIFF
--- a/src/app/(homepage)/page.tsx
+++ b/src/app/(homepage)/page.tsx
@@ -110,12 +110,19 @@ export default function TopPage() {
                 <strong className={`${geistMono.className}`}>
                   {item.date}:
                 </strong>{' '}
-                {item.url ? (
-                  <Link href={item.url} target="_blank" className="underline">
-                    {item.description}
-                  </Link>
-                ) : (
-                  item.description
+                {item.content.map((part, partIndex) =>
+                  typeof part === 'string' ? (
+                    <span key={partIndex}>{part}</span>
+                  ) : (
+                    <Link
+                      key={partIndex}
+                      href={part.url}
+                      target="_blank"
+                      className="underline"
+                    >
+                      {part.text}
+                    </Link>
+                  )
                 )}
               </div>
             ))}

--- a/src/app/(homepage)/page.tsx
+++ b/src/app/(homepage)/page.tsx
@@ -13,13 +13,27 @@ const geistMono = Geist_Mono({
 })
 
 import { VisualAtomDesign } from '@/components/visual-atom-design'
-import { members, newsItems } from '@/data/topPageData'
+import { members, newsItems, type NewsTag } from '@/data/topPageData'
 import { PaperOceanDesign } from '@/components/paper-ocean-design'
 
 // shadcn/ui components
 import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+
+// Tag color mapping
+const getTagColor = (tag: NewsTag): string => {
+  const colors: Record<NewsTag, string> = {
+    'Workshop/Event':
+      'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
+    Report: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+    'Paper Accepted':
+      'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200',
+    Announcement:
+      'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200',
+  }
+  return colors[tag]
+}
 
 export default function TopPage() {
   return (
@@ -104,26 +118,39 @@ export default function TopPage() {
           <h1 className="mb-2 text-2xl font-semibold leading-7 tracking-wider text-foreground shadow-background drop-shadow-md sm:text-2xl md:text-3xl md:leading-8">
             Recent News
           </h1>
-          <div className="space-y-2">
+          <div className="space-y-4">
             {newsItems.map((item, index) => (
-              <div key={index} className="text-sm sm:text-base">
-                <strong className={`${geistMono.className}`}>
-                  {item.date}:
-                </strong>{' '}
-                {item.content.map((part, partIndex) =>
-                  typeof part === 'string' ? (
-                    <span key={partIndex}>{part}</span>
-                  ) : (
-                    <Link
-                      key={partIndex}
-                      href={part.url}
-                      target="_blank"
-                      className="underline"
+              <div key={index} className="flex flex-col gap-1">
+                <div className="flex items-center gap-2">
+                  <span
+                    className={`${geistMono.className} text-xs font-semibold text-muted-foreground sm:text-sm`}
+                  >
+                    {item.date}
+                  </span>
+                  {item.tag && (
+                    <span
+                      className={`inline-block rounded-md px-2 py-0.5 text-xs font-semibold ${getTagColor(item.tag)}`}
                     >
-                      {part.text}
-                    </Link>
-                  )
-                )}
+                      {item.tag}
+                    </span>
+                  )}
+                </div>
+                <div className="text-sm sm:text-base">
+                  {item.content.map((part, partIndex) =>
+                    typeof part === 'string' ? (
+                      <span key={partIndex}>{part}</span>
+                    ) : (
+                      <Link
+                        key={partIndex}
+                        href={part.url}
+                        target="_blank"
+                        className="underline"
+                      >
+                        {part.text}
+                      </Link>
+                    )
+                  )}
+                </div>
               </div>
             ))}
           </div>

--- a/src/app/(homepage)/page.tsx
+++ b/src/app/(homepage)/page.tsx
@@ -118,7 +118,7 @@ export default function TopPage() {
           <h1 className="mb-2 text-2xl font-semibold leading-7 tracking-wider text-foreground shadow-background drop-shadow-md sm:text-2xl md:text-3xl md:leading-8">
             Recent News
           </h1>
-          <div className="space-y-4">
+          <div className="max-h-[400px] space-y-4 overflow-y-auto pr-2 sm:max-h-[500px]">
             {newsItems.map((item, index) => (
               <div key={index} className="flex flex-col gap-1">
                 <div className="flex items-center gap-2">

--- a/src/data/topPageData.ts
+++ b/src/data/topPageData.ts
@@ -1,39 +1,103 @@
+// Type definitions for news content
+export type NewsContentPart = string | { text: string; url: string }
+
+export interface NewsItem {
+  date: string
+  content: NewsContentPart[]
+}
+
 // Sample data for recent news
-export const newsItems = [
+export const newsItems: NewsItem[] = [
+  {
+    date: '2026-04-07',
+    content: [
+      'We hosted the ',
+      {
+        text: 'ASPIRE Computer Vision Workshop at Tokyo',
+        url: 'https://research-p.com/event/2690',
+      },
+      '.',
+    ],
+  },
   {
     date: '2025-12-21',
-    description: 'Two workshops are accepted at CVPR 2026.',
-    url: '',
+    content: [
+      'Two workshops are accepted at CVPR 2026 (',
+      {
+        text: 'VGI Workshop',
+        url: 'https://cvpr2026-vgi-workshop.limitlab.xyz',
+      },
+      ', ',
+      {
+        text: 'BigMAC Workshop',
+        url: 'https://cvpr2026-bigmac-workshop.limitlab.xyz',
+      },
+      ').',
+    ],
   },
   {
     date: '2025-10-31',
-    description: 'Released the ICCV 2025 Report.',
-    url: 'https://cdn.limitlab.xyz/iccv2025/r/iccv2025-report_latest-en.pdf',
+    content: [
+      'Released the ',
+      {
+        text: 'ICCV 2025 Report',
+        url: 'https://cdn.limitlab.xyz/iccv2025/r/iccv2025-report_latest-en.pdf',
+      },
+      '.',
+    ],
   },
   {
     date: '2025-09-26',
-    description: 'We jointly hosted the Cambridge Computer Vision Workshop.',
-    url: 'https://cambridgecv-workshop-2025sep.limitlab.xyz/',
+    content: [
+      'We jointly hosted the ',
+      {
+        text: 'Cambridge Computer Vision Workshop',
+        url: 'https://cambridgecv-workshop-2025sep.limitlab.xyz/',
+      },
+      '.',
+    ],
   },
   {
     date: '2025-07-14',
-    description: 'Ryousuke Yamada appointed JSPS research fellow at FunAI Lab.',
-    url: 'https://fundamentalailab.github.io/',
+    content: [
+      'Ryousuke Yamada appointed JSPS research fellow at ',
+      {
+        text: 'FunAI Lab',
+        url: 'https://fundamentalailab.github.io/',
+      },
+      '.',
+    ],
   },
   {
     date: '2025-06-16',
-    description: 'Released the CVPR 2025 Report.',
-    url: 'https://hirokatsukataoka.net/temp/presen/250616CVPR2025Report_FinalizedVer.pdf',
+    content: [
+      'Released the ',
+      {
+        text: 'CVPR 2025 Report',
+        url: 'https://hirokatsukataoka.net/temp/presen/250616CVPR2025Report_FinalizedVer.pdf',
+      },
+      '.',
+    ],
   },
   {
     date: '2025-06-01',
-    description: 'Two workshops are accepted at ICCV 2025.',
-    url: '',
+    content: [
+      'Two workshops are accepted at ICCV 2025 (',
+      {
+        text: 'LIMIT Workshop',
+        url: 'https://iccv2025-limit-workshop.limitlab.xyz',
+      },
+      ', ',
+      {
+        text: 'FOUND Workshop',
+        url: 'https://iccv2025-found-workshop.limitlab.xyz',
+      },
+      ').',
+    ],
   },
   {
     date: '2025-06-01',
-    description: 'Our official website is now live.',
-    url: '',
+    content: ['Our official website is now live.'],
   },
 ]
 

--- a/src/data/topPageData.ts
+++ b/src/data/topPageData.ts
@@ -1,8 +1,15 @@
 // Type definitions for news content
 export type NewsContentPart = string | { text: string; url: string }
 
+export type NewsTag =
+  | 'Workshop/Event'
+  | 'Report'
+  | 'Paper Accepted'
+  | 'Announcement'
+
 export interface NewsItem {
   date: string
+  tag?: NewsTag // Optional tag
   content: NewsContentPart[]
 }
 
@@ -10,6 +17,7 @@ export interface NewsItem {
 export const newsItems: NewsItem[] = [
   {
     date: '2026-04-07',
+    tag: 'Workshop/Event',
     content: [
       'We hosted the ',
       {
@@ -21,6 +29,7 @@ export const newsItems: NewsItem[] = [
   },
   {
     date: '2025-12-21',
+    tag: 'Workshop/Event',
     content: [
       'Two workshops are accepted at CVPR 2026 (',
       {
@@ -37,6 +46,7 @@ export const newsItems: NewsItem[] = [
   },
   {
     date: '2025-10-31',
+    tag: 'Report',
     content: [
       'Released the ',
       {
@@ -48,6 +58,7 @@ export const newsItems: NewsItem[] = [
   },
   {
     date: '2025-09-26',
+    tag: 'Workshop/Event',
     content: [
       'We jointly hosted the ',
       {
@@ -59,6 +70,7 @@ export const newsItems: NewsItem[] = [
   },
   {
     date: '2025-07-14',
+    tag: 'Announcement',
     content: [
       'Ryousuke Yamada appointed JSPS research fellow at ',
       {
@@ -70,6 +82,7 @@ export const newsItems: NewsItem[] = [
   },
   {
     date: '2025-06-16',
+    tag: 'Report',
     content: [
       'Released the ',
       {
@@ -81,6 +94,7 @@ export const newsItems: NewsItem[] = [
   },
   {
     date: '2025-06-01',
+    tag: 'Workshop/Event',
     content: [
       'Two workshops are accepted at ICCV 2025 (',
       {
@@ -97,6 +111,7 @@ export const newsItems: NewsItem[] = [
   },
   {
     date: '2025-06-01',
+    tag: 'Announcement',
     content: ['Our official website is now live.'],
   },
 ]


### PR DESCRIPTION
## Summary
- Added support for inline links within news descriptions
- Changed news data structure from `description` + `url` to `content` array
- Enables flexible link placement like "Released the [Report] in [English] and [日本語]"

## Changes
- Updated `NewsItem` type to use `content: NewsContentPart[]` instead of `description` + `url`
- Modified rendering logic in `page.tsx` to handle mixed text and link elements
- Updated all existing news items to use the new format

## Test plan
- [ ] Verify news items display correctly with inline links
- [ ] Check that multiple links in a single news item work properly
- [ ] Confirm backward compatibility (news items with no links still work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)