### PR TITLE
feat: modernize design refresh across all pages

### DIFF
--- a/src/app/(homepage)/contact/page.tsx
+++ b/src/app/(homepage)/contact/page.tsx
@@ -1,186 +1,58 @@
 'use client'
 
-import { PiSlackLogoLight } from 'react-icons/pi'
+import { SiSlack } from 'react-icons/si'
 import Link from 'next/link'
 import { RiGlobalLine } from 'react-icons/ri'
 
-// shadcn/ui components
-import {
-  Card,
-  CardHeader,
-  CardContent,
-  CardTitle,
-  CardDescription,
-} from '@/components/ui/card'
-
 export default function ContactPage() {
-  // const [name, setName] = useState('')
-  // const [email, setEmail] = useState('')
-  // const [subject, setSubject] = useState('')
-  // const [message, setMessage] = useState('')
-  // const [isSubmitting, setIsSubmitting] = useState(false)
-  // const [submitStatus, setSubmitStatus] = useState<
-  //   'idle' | 'success' | 'error'
-  // >('idle')
-
-  // Form submission handler
-  // const handleSubmit = async (e: React.FormEvent) => {
-  //   e.preventDefault()
-  //   setIsSubmitting(true)
-  //   setSubmitStatus('idle')
-
-  //   try {
-  //     // Simulate API call with timeout
-  //     await new Promise((resolve) => setTimeout(resolve, 1500))
-  //     console.log('Sending message:', { name, email, subject, message })
-
-  //     // Reset form
-  //     setName('')
-  //     setEmail('')
-  //     setSubject('')
-  //     setMessage('')
-  //     setSubmitStatus('success')
-  //   } catch (error) {
-  //     console.error('Error sending message:', error)
-  //     setSubmitStatus('error')
-  //   } finally {
-  //     setIsSubmitting(false)
-  //   }
-  // }
-
   return (
-    <div className="flex w-11/12 flex-1 flex-col items-center gap-8 py-8 sm:w-4/5 sm:gap-12 md:gap-16">
-      {/* Page Title */}
-      <div className="w-full max-w-[1000px] text-center">
-        <h1 className="mb-2 text-2xl font-semibold leading-7 tracking-wider text-foreground shadow-background drop-shadow-md sm:text-3xl md:text-4xl md:leading-10">
+    <div className="container mx-auto w-full max-w-4xl space-y-12 px-6 py-12 md:px-8">
+      {/* Page header */}
+      <header className="fade-in-up flex flex-col items-start gap-3">
+        <h1 className="gradient-text text-4xl font-extrabold tracking-tight md:text-5xl">
           Contact Us
         </h1>
-        <p className="mx-auto mt-4 max-w-2xl text-sm text-sub sm:text-base">
+        <div className="section-accent" />
+        <p className="max-w-2xl text-sm text-muted-foreground sm:text-base">
           Have questions about our research or interested in collaboration?
-          We&apos;d love to hear from you. Reach out using the form below or
-          through our contact information.
+          We&apos;d love to hear from you. Join our community via the channels
+          below.
         </p>
-      </div>
+      </header>
 
-      {/* Main Content */}
-      <div className="flex w-full max-w-[1000px] flex-col gap-8 lg:flex-row">
-        {/* Contact Information */}
-        <div className="w-full animate-fade-in-top">
-          <Card className="bg-card/70 h-full overflow-hidden border-block-border backdrop-blur-sm">
-            <CardHeader className="pb-2">
-              <CardTitle className="text-xl font-semibold sm:text-2xl">
-                How to connect our community
-              </CardTitle>
-              <CardDescription className="text-sm font-semibold text-sub">
-                Connect with LIMIT.Community members through various channels
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="space-y-6">
-              {/* Contact Details */}
-              <div className="space-y-4">
-                <div className="flex items-start gap-3">
-                  <PiSlackLogoLight className="mt-1 size-5 shrink-0 text-accent-foreground" />
-                  <div>
-                    <h3 className="font-medium">LIMIT.Community Slack WG</h3>
-                    <div className="flex w-full flex-wrap gap-2 sm:flex-nowrap sm:gap-4">
-                      <p className="text-sm text-sub">
-                        Join our LIMIT.Community Slack WG from the link below.
-                      </p>
-                      <br />
-                    </div>
-                    <div className="flex w-full flex-wrap gap-2 sm:flex-nowrap sm:gap-4">
-                      <Link
-                        href="https://join.slack.com/t/limit-community/shared_invite/zt-1oov3gv0h-kaLICu0jm_wzm0_H6D46Lw"
-                        target="_blank"
-                        className="flex h-auto items-center gap-1 rounded-md border border-button-project bg-button-project px-2 py-1.5 text-button-project-foreground hover:bg-button-project-hovered hover:text-button-project-foreground-hovered sm:gap-2 sm:px-3 sm:py-2"
-                      >
-                        <RiGlobalLine className="size-4 sm:size-5" />
-                        <span className="text-xs font-medium sm:text-sm">
-                          Join Slack WG
-                        </span>
-                      </Link>
-                    </div>
-                  </div>
-                </div>
+      {/* Slack panel */}
+      <section className="glass-strong relative overflow-hidden rounded-3xl p-8 shadow-lg sm:p-10 md:p-12">
+        <div className="gradient-mesh absolute inset-0" aria-hidden="true" />
 
-                {/* <div className="flex items-start gap-3">
-                  <HiOutlineMail className="mt-1 size-5 shrink-0 text-accent-foreground" />
-                  <div>
-                    <h3 className="font-medium">Email</h3>
-                    <p className="text-sm text-sub">
-                      contact@limitlab.example.com
-                    </p>
-                  </div>
-                </div> */}
+        <div className="relative z-10 flex flex-col items-start gap-6 md:flex-row md:items-center md:gap-8">
+          <div className="flex size-16 shrink-0 items-center justify-center rounded-2xl bg-brand-blue-a4 sm:size-20">
+            <SiSlack className="size-8 text-brand-blue-11 sm:size-10" />
+          </div>
 
-                {/* <div className="flex items-start gap-3">
-                  <HiOutlinePhone className="mt-1 size-5 shrink-0 text-accent-foreground" />
-                  <div>
-                    <h3 className="font-medium">Phone</h3>
-                    <p className="text-sm text-sub">+81 (0)3-1234-5678</p>
-                  </div>
-                </div> */}
-
-                {/* <div className="flex items-start gap-3">
-                  <HiOutlineAcademicCap className="mt-1 size-5 shrink-0 text-accent-foreground" />
-                  <div>
-                    <h3 className="font-medium">Academic Inquiries</h3>
-                    <p className="text-sm text-sub">
-                      For research collaborations and academic inquiries:
-                      <br />
-                      research@limitlab.example.com
-                    </p>
-                  </div>
-                </div> */}
-              </div>
-
-              {/* <Separator className="h-[2px]" /> */}
-
-              {/* Social Links */}
-              {/* <div>
-                <h3 className="mb-3 font-medium">Follow Us</h3>
-                <div className="flex gap-4">
-                  <Link
-                    href="https://github.com/limitlab"
-                    target="_blank"
-                    className="flex items-center gap-2 rounded-md border border-input bg-button-background px-3 py-2 text-sm text-button-foreground hover:bg-accent hover:text-accent-foreground"
-                  >
-                    <RxGithubLogo className="size-4" />
-                    <span>GitHub</span>
-                  </Link>
-                  <Link
-                    href="https://twitter.com/limitlab"
-                    target="_blank"
-                    className="flex items-center gap-2 rounded-md border border-input bg-button-background px-3 py-2 text-sm text-button-foreground hover:bg-accent hover:text-accent-foreground"
-                  >
-                    <PiXLogo className="size-4" />
-                    <span>X</span>
-                  </Link>
-                </div>
-              </div> */}
-            </CardContent>
-          </Card>
+          <div className="flex-1 space-y-3">
+            <h2 className="text-xl font-bold tracking-tight sm:text-2xl">
+              LIMIT.Community Slack WG
+            </h2>
+            <p className="text-sm leading-relaxed text-muted-foreground sm:text-base">
+              Connect with LIMIT.Community members, share ideas, ask questions,
+              and stay up to date on research and events. Join our Slack working
+              group from the link below.
+            </p>
+            <div className="pt-2">
+              <Link
+                href="https://join.slack.com/t/limit-community/shared_invite/zt-1oov3gv0h-kaLICu0jm_wzm0_H6D46Lw"
+                target="_blank"
+                className="inline-flex items-center gap-2 rounded-xl border border-button-project bg-button-project px-4 py-2.5 text-button-project-foreground shadow-sm transition-all hover:-translate-y-0.5 hover:bg-button-project-hovered hover:text-button-project-foreground-hovered hover:shadow-md"
+              >
+                <RiGlobalLine className="size-4 sm:size-5" />
+                <span className="text-sm font-semibold sm:text-base">
+                  Join Slack WG
+                </span>
+              </Link>
+            </div>
+          </div>
         </div>
-
-        {/* Contact Form */}
-      </div>
-
-      {/* Map Section */}
-      {/* <div className="w-full max-w-[1000px] overflow-hidden rounded-xl border border-block-border">
-        <div className="aspect-video w-full">
-          <iframe
-            src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3240.827853707428!2d139.76454987617074!3d35.68124152999252!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x60188bfbd89f700b%3A0x277c49ba34ed38!2sTokyo%20Station!5e0!3m2!1sen!2sjp!4v1715530217062!5m2!1sen!2sjp"
-            width="100%"
-            height="100%"
-            style={{ border: 0 }}
-            allowFullScreen
-            loading="lazy"
-            referrerPolicy="no-referrer-when-downgrade"
-            title="LIMIT.Lab Location"
-            className="bg-muted"
-          ></iframe>
-        </div>
-      </div> */}
+      </section>
     </div>
   )
 }

--- a/src/app/(homepage)/events-reports/page.tsx
+++ b/src/app/(homepage)/events-reports/page.tsx
@@ -5,12 +5,10 @@ import Image from 'next/image'
 import { RxFile, RxGithubLogo, RxCalendar } from 'react-icons/rx'
 import { RiGlobalLine } from 'react-icons/ri'
 import Link from 'next/link'
-import { Separator } from '@radix-ui/react-separator'
 
 import { sampleEventsReports } from '@/data/eventsReportsPageData'
 
 // shadcn/ui components
-import { Card, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import {
   Select,
@@ -46,198 +44,189 @@ export default function EventsReportsPage() {
         conferenceFilter === 'all' || item.conference === conferenceFilter
       return typeMatch && yearMatch && conferenceMatch
     })
-    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()) // Sort by date in descending order (newest first)
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
 
   return (
-    <div className="flex w-11/12 flex-1 flex-col items-center gap-6 py-8 sm:w-4/5 sm:gap-8">
-      {/* Page Title */}
-      <div className="w-full max-w-[1000px] text-center">
-        <h1 className="mb-2 text-2xl font-semibold leading-7 tracking-wider text-foreground shadow-background drop-shadow-md sm:text-3xl md:text-4xl md:leading-10">
+    <div className="container mx-auto w-full max-w-6xl space-y-12 px-6 py-12 md:px-8">
+      {/* Page header */}
+      <header className="fade-in-up flex flex-col items-start gap-3">
+        <h1 className="gradient-text text-4xl font-extrabold tracking-tight md:text-5xl">
           Events &amp; Reports
         </h1>
-        <p className="mx-auto mt-4 max-w-2xl text-sm text-sub sm:text-base">
+        <div className="section-accent" />
+        <p className="max-w-2xl text-sm text-muted-foreground sm:text-base">
           Explore our workshops, events, and published reports. Use the filters
           below to find activities by type, year, or conference.
         </p>
-      </div>
-      <div className="flex w-full max-w-[1000px] flex-col items-center gap-5 rounded-3xl border border-block-border px-4 pb-8 pt-6 sm:gap-7 sm:px-8 sm:pb-12 sm:pt-8 md:px-10 md:pb-16 md:pt-10">
-        {/* Filters */}
-        <div className="flex w-full flex-wrap gap-3 self-end sm:flex-nowrap sm:gap-4 sm:self-end">
-          {/* Type Filter */}
-          <div className="flex w-full flex-col items-start gap-1 sm:w-auto sm:gap-2">
-            <div className="text-sm font-semibold sm:text-base">Type</div>
-            <Select
-              value={typeFilter}
-              onValueChange={(val) => setTypeFilter(val)}
-            >
-              <SelectTrigger className="w-full sm:w-[120px]">
-                <SelectValue placeholder="Type" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">All</SelectItem>
-                {types.map((type) => (
-                  <SelectItem key={type} value={type}>
-                    {type}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
+      </header>
 
-          {/* Year Filter */}
-          <div className="flex w-full flex-col items-start gap-1 sm:w-auto sm:gap-2">
-            <div className="text-sm font-semibold sm:text-base">Year</div>
-            <Select
-              value={yearFilter}
-              onValueChange={(val) => setYearFilter(val)}
-            >
-              <SelectTrigger className="w-full sm:w-[100px]">
-                <SelectValue placeholder="Year" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">All</SelectItem>
-                {years.map((y) => (
-                  <SelectItem key={y} value={String(y)}>
-                    {y}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-
-          {/* Conference Filter */}
-          <div className="flex w-full flex-col items-start gap-1 sm:w-auto sm:gap-2">
-            <div className="text-sm font-semibold sm:text-base">Conference</div>
-            <Select
-              value={conferenceFilter}
-              onValueChange={(val) => setConferenceFilter(val)}
-            >
-              <SelectTrigger className="w-full sm:w-[180px]">
-                <SelectValue placeholder="Conference" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">All</SelectItem>
-                {conferences.map((conference) => (
-                  <SelectItem key={conference} value={conference}>
-                    {conference}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
+      {/* Filters */}
+      <div className="glass flex flex-wrap items-end justify-end gap-3 rounded-2xl p-4 shadow-sm sm:gap-4 sm:p-5">
+        <div className="flex w-full flex-col items-start gap-1.5 sm:w-auto">
+          <label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            Type
+          </label>
+          <Select
+            value={typeFilter}
+            onValueChange={(val) => setTypeFilter(val)}
+          >
+            <SelectTrigger className="w-full sm:w-[140px]">
+              <SelectValue placeholder="Type" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All</SelectItem>
+              {types.map((type) => (
+                <SelectItem key={type} value={type}>
+                  {type}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
 
-        {/* Events & Reports List */}
-        <div className="flex w-full flex-col items-center gap-4">
-          {filteredItems.map((item) => (
-            <Card
-              key={item.id}
-              className="w-full place-content-center p-3 sm:p-4"
-            >
-              <CardContent className="flex h-full flex-col items-center gap-4 p-0 md:flex-row md:items-center">
-                {/* Item Image */}
-                <div className="w-full overflow-hidden rounded-md md:w-1/3 md:min-w-60 lg:min-w-80">
-                  <AspectRatio ratio={16 / 9}>
-                    <Image
-                      src={item.imageUrl}
-                      alt={item.title}
-                      fill
-                      className="rounded-md object-cover object-center"
-                      priority={item.id === 1}
-                    />
-                  </AspectRatio>
-                </div>
+        <div className="flex w-full flex-col items-start gap-1.5 sm:w-auto">
+          <label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            Year
+          </label>
+          <Select
+            value={yearFilter}
+            onValueChange={(val) => setYearFilter(val)}
+          >
+            <SelectTrigger className="w-full sm:w-[120px]">
+              <SelectValue placeholder="Year" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All</SelectItem>
+              {years.map((y) => (
+                <SelectItem key={y} value={String(y)}>
+                  {y}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
 
-                {/* Item Details */}
-                <div className="flex w-full flex-1 flex-col items-start justify-between gap-3 py-1 md:h-full md:py-2">
-                  {/* Tags */}
-                  <div className="flex w-fit gap-2 self-end">
-                    <Badge
-                      variant="type"
-                      className="text-xs font-medium sm:text-sm"
-                    >
+        <div className="flex w-full flex-col items-start gap-1.5 sm:w-auto">
+          <label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            Conference
+          </label>
+          <Select
+            value={conferenceFilter}
+            onValueChange={(val) => setConferenceFilter(val)}
+          >
+            <SelectTrigger className="w-full sm:w-[200px]">
+              <SelectValue placeholder="Conference" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All</SelectItem>
+              {conferences.map((conference) => (
+                <SelectItem key={conference} value={conference}>
+                  {conference}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {/* Events & Reports list */}
+      <div className="space-y-5">
+        {filteredItems.map((item) => (
+          <article
+            key={item.id}
+            className="glass card-hover overflow-hidden rounded-2xl p-4 shadow-sm sm:p-5"
+          >
+            <div className="flex h-full flex-col items-stretch gap-5 md:flex-row md:items-start">
+              {/* Image */}
+              <div className="w-full overflow-hidden rounded-xl md:w-1/3 md:min-w-60 lg:min-w-72">
+                <AspectRatio ratio={16 / 9}>
+                  <Image
+                    src={item.imageUrl}
+                    alt={item.title}
+                    fill
+                    className="rounded-xl object-cover object-center"
+                    priority={item.id === 1}
+                  />
+                </AspectRatio>
+              </div>
+
+              {/* Details */}
+              <div className="flex flex-1 flex-col justify-between gap-3 py-1">
+                <div className="space-y-3">
+                  <div className="flex flex-wrap gap-2">
+                    <Badge variant="type" className="text-xs font-medium">
                       {item.type}
                     </Badge>
                     {item.conference && (
                       <Badge
                         variant="conference"
-                        className="text-xs font-medium sm:text-sm"
+                        className="text-xs font-medium"
                       >
                         {item.conference}
                       </Badge>
                     )}
-                    <Badge
-                      variant="year"
-                      className="text-xs font-medium sm:text-sm"
-                    >
+                    <Badge variant="year" className="text-xs font-medium">
                       {item.year}
                     </Badge>
                   </div>
 
-                  {/* Title and Date */}
-                  <div className="flex w-full flex-col gap-1">
-                    <div className="flex w-full flex-col gap-1">
-                      <h2 className="w-full text-base font-semibold leading-5 sm:text-lg sm:leading-6">
-                        {item.title}
-                      </h2>
-                      <Separator
-                        orientation="horizontal"
-                        className="h-px w-full bg-underline"
-                      />
-                    </div>
-                    <div className="flex items-center gap-1.5 text-xs text-foreground opacity-70">
-                      <RxCalendar className="size-3.5" />
-                      <span>{item.date}</span>
-                    </div>
-                    <div className="mt-1 w-full text-sm text-foreground opacity-75">
-                      {item.description}
-                    </div>
+                  <h2 className="text-base font-semibold leading-snug tracking-tight sm:text-lg md:text-xl">
+                    {item.title}
+                  </h2>
+
+                  <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                    <RxCalendar className="size-3.5" />
+                    <span>{item.date}</span>
                   </div>
 
-                  {/* Action Buttons */}
-                  <div className="flex w-full flex-wrap gap-2 sm:flex-nowrap sm:gap-4">
-                    {item.websiteUrl && (
-                      <Link
-                        href={item.websiteUrl}
-                        target="_blank"
-                        className="flex h-auto items-center gap-1 rounded-md border border-button-project bg-button-project px-2 py-1.5 text-button-project-foreground hover:bg-button-project-hovered hover:text-button-project-foreground-hovered sm:gap-2 sm:px-3 sm:py-2"
-                      >
-                        <RiGlobalLine className="size-4 sm:size-5" />
-                        <span className="text-xs font-medium sm:text-sm">
-                          Website
-                        </span>
-                      </Link>
-                    )}
-                    {item.pdfFileUrl && (
-                      <Link
-                        href={item.pdfFileUrl}
-                        target="_blank"
-                        className="flex h-auto items-center gap-1 rounded-md border border-button-pdf bg-button-pdf px-2 py-1.5 text-button-pdf-foreground hover:bg-button-pdf-hovered hover:text-button-pdf-foreground-hovered sm:gap-2 sm:px-3 sm:py-2"
-                      >
-                        <RxFile className="size-4 sm:size-5" />
-                        <span className="text-xs font-medium sm:text-sm">
-                          PDF
-                        </span>
-                      </Link>
-                    )}
-                    {item.githubUrl && (
-                      <Link
-                        href={item.githubUrl}
-                        target="_blank"
-                        className="flex h-auto items-center gap-1 rounded-md border border-button-github bg-button-github px-2 py-1.5 text-button-github-foreground hover:bg-button-github-hovered hover:text-button-github-foreground-hovered sm:gap-2 sm:px-3 sm:py-2"
-                      >
-                        <RxGithubLogo className="size-4 sm:size-5" />
-                        <span className="text-xs font-medium sm:text-sm">
-                          GitHub
-                        </span>
-                      </Link>
-                    )}
-                  </div>
+                  <p className="text-foreground/80 text-sm leading-relaxed">
+                    {item.description}
+                  </p>
                 </div>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
+
+                {/* Action buttons */}
+                <div className="flex flex-wrap gap-2 pt-2 sm:gap-3">
+                  {item.websiteUrl && (
+                    <Link
+                      href={item.websiteUrl}
+                      target="_blank"
+                      className="flex items-center gap-1.5 rounded-lg border border-button-project bg-button-project px-3 py-1.5 text-button-project-foreground transition-colors hover:bg-button-project-hovered hover:text-button-project-foreground-hovered sm:gap-2"
+                    >
+                      <RiGlobalLine className="size-4" />
+                      <span className="text-xs font-medium sm:text-sm">
+                        Website
+                      </span>
+                    </Link>
+                  )}
+                  {item.pdfFileUrl && (
+                    <Link
+                      href={item.pdfFileUrl}
+                      target="_blank"
+                      className="flex items-center gap-1.5 rounded-lg border border-button-pdf bg-button-pdf px-3 py-1.5 text-button-pdf-foreground transition-colors hover:bg-button-pdf-hovered hover:text-button-pdf-foreground-hovered sm:gap-2"
+                    >
+                      <RxFile className="size-4" />
+                      <span className="text-xs font-medium sm:text-sm">
+                        PDF
+                      </span>
+                    </Link>
+                  )}
+                  {item.githubUrl && (
+                    <Link
+                      href={item.githubUrl}
+                      target="_blank"
+                      className="flex items-center gap-1.5 rounded-lg border border-button-github bg-button-github px-3 py-1.5 text-button-github-foreground transition-colors hover:bg-button-github-hovered hover:text-button-github-foreground-hovered sm:gap-2"
+                    >
+                      <RxGithubLogo className="size-4" />
+                      <span className="text-xs font-medium sm:text-sm">
+                        GitHub
+                      </span>
+                    </Link>
+                  )}
+                </div>
+              </div>
+            </div>
+          </article>
+        ))}
       </div>
     </div>
   )

--- a/src/app/(homepage)/layout.tsx
+++ b/src/app/(homepage)/layout.tsx
@@ -9,10 +9,12 @@ export default function SharedUILayout({
   children: React.ReactNode
 }) {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-background from-20% via-background-gradation-1 via-50% to-background-gradation-2 to-90%">
-      <div className="bg-animated simple-grid flex min-h-screen w-full flex-col items-center overflow-x-hidden">
+    <div className="relative min-h-screen bg-gradient-to-br from-background from-20% via-background-gradation-1 via-50% to-background-gradation-2 to-90%">
+      <div className="bg-animated simple-grid relative flex min-h-screen w-full flex-col items-center overflow-x-hidden">
+        {/* Soft brand-colored radial mesh behind everything */}
+        <div className="gradient-mesh absolute inset-0" aria-hidden="true" />
         <Header />
-        <main className="flex w-full flex-1 flex-col items-center">
+        <main className="relative flex w-full flex-1 flex-col items-center pt-24 sm:pt-28">
           {children}
         </main>
         <Footer />

--- a/src/app/(homepage)/page.tsx
+++ b/src/app/(homepage)/page.tsx
@@ -17,7 +17,6 @@ import { members, newsItems, type NewsTag } from '@/data/topPageData'
 import { PaperOceanDesign } from '@/components/paper-ocean-design'
 
 // shadcn/ui components
-import { Card, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 
@@ -25,105 +24,133 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 const getTagColor = (tag: NewsTag): string => {
   const colors: Record<NewsTag, string> = {
     'Workshop/Event':
-      'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200',
-    Report: 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200',
+      'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-200',
+    Report:
+      'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-200',
     'Paper Accepted':
-      'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200',
+      'bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-200',
     Announcement:
-      'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200',
+      'bg-gray-100 text-gray-800 dark:bg-gray-700/60 dark:text-gray-200',
   }
   return colors[tag]
 }
 
 export default function TopPage() {
   return (
-    <div className="flex w-11/12 flex-1 flex-col items-center justify-start gap-12 sm:w-4/5 sm:gap-16 md:gap-20">
-      {/* About Us */}
-      <div className="relative mt-8 flex max-w-[1000px] animate-slide-in-left flex-col items-center gap-6 px-4 py-8 before:absolute before:inset-y-0 before:-left-full before:z-0 before:block before:w-[200%] before:rounded-r-3xl before:border before:border-block-border sm:mt-12 sm:px-8 sm:py-10 md:mt-16 md:flex-row md:items-center md:gap-8 md:px-12 md:py-14 lg:px-20">
-        <div className="relative flex animate-fade-in-top flex-col items-start gap-3 text-foreground animate-delay-700 animate-duration-500">
-          <h1 className="mb-2 text-2xl font-semibold leading-7 tracking-wider text-foreground shadow-background drop-shadow-md sm:text-2xl md:text-3xl md:leading-8">
-            Limited Resources, Unlimited Impact with Multimodal AI Models
-          </h1>
-          <p className="mb-5 w-full text-wrap text-sm sm:text-base">
-            AI foundation models are increasingly dominating various academic
-            and industrial fields, yet the R&D of related technologies is
-            controlled by limited institutions capable of managing extensive
-            computational and data resources. To counter this dominance, there
-            is a critical need for technologies that can develop practical AI
-            foundation models using the standard computational and data
-            resources. It is said that the scaling laws no longer provide the
-            reliable roadmap for developing AI foundational models. Our
-            community (LIMIT.Community) and the international lab (LIMIT.Lab)
-            therefore aim to put in place exactly those technologies that permit
-            the construction of {'{'}Vision, Vision-Language, Multimodal{'}'}
-            AI foundational models even when compute and data are limited.
-            Drawing on our members’ prior successes in (i) generative
-            pre-training methods that can be applied horizontally across any
-            modality with image, video, 3D, & audio, and (ii) high-quality AI
-            models from extremely scarce data (including a single image), we
-            have been committed to AI multimodal foundational models under very
-            limited resources. As of 2025, LIMIT.Lab is composed primarily of
-            international research teams from Japan, UK, and Germany. Through
-            collaborative research projects and the workshop organization, we
-            actively foster global exchange in the field of AI and related
-            areas.
-          </p>
-          <h2 className="text-sm font-semibold sm:text-base">
-            Check out upcoming events
-          </h2>
-          <div className="flex flex-wrap gap-3 sm:gap-4">
-            <Button
-              className="h-auto rounded-2xl bg-button-background py-2 text-button-foreground hover:animate-scale-up-sm hover:bg-accent hover:text-accent-foreground sm:h-10 sm:py-0"
-              size="sm"
-              asChild
-            >
-              <Link
-                href="https://cvpr2026-vgi-workshop.limitlab.xyz"
-                target="_blank"
-              >
-                <span className="text-xs font-semibold tracking-wider sm:text-sm">
-                  CVPR 2026 VGI Workshop
-                </span>
-                <HiCursorClick className="size-4 sm:size-5" />
-              </Link>
-            </Button>
-            <Button
-              className="h-auto rounded-2xl bg-button-background py-2 text-button-foreground hover:animate-scale-up-sm hover:bg-accent hover:text-accent-foreground sm:h-10 sm:py-0"
-              size="sm"
-              asChild
-            >
-              <Link
-                href="https://cvpr2026-bigmac-workshop.limitlab.xyz"
-                target="_blank"
-              >
-                <span className="text-xs font-semibold tracking-wider sm:text-sm">
-                  CVPR 2026 BigMAC Workshop
-                </span>
-                <HiCursorClick className="size-4 sm:size-5" />
-              </Link>
-            </Button>
+    <div className="container mx-auto w-full max-w-6xl space-y-24 px-6 py-12 md:px-8">
+      {/* Hero */}
+      <section className="fade-in-up border-border/50 bg-background/40 relative overflow-hidden rounded-3xl border px-6 py-14 backdrop-blur-md md:px-12 md:py-20 lg:py-24">
+        {/* Decorative backdrop */}
+        <div
+          className="gradient-mesh pointer-events-none absolute inset-0"
+          aria-hidden="true"
+        />
+
+        <div className="relative z-10 flex flex-col items-center gap-10 lg:flex-row lg:items-center lg:gap-14">
+          {/* Atom visual */}
+          <div className="flex shrink-0 items-center justify-center">
+            <div className="relative">
+              <div
+                className="absolute inset-0 -z-10 rounded-full blur-2xl"
+                style={{
+                  background:
+                    'radial-gradient(circle, var(--blue-a7) 0%, transparent 70%)',
+                }}
+              />
+              <VisualAtomDesign />
+            </div>
+          </div>
+
+          {/* Copy */}
+          <div className="flex flex-1 flex-col items-start gap-5">
+            <span className="text-[10px] font-semibold uppercase tracking-[0.3em] text-muted-foreground md:text-xs">
+              International Research Collective
+            </span>
+            <h1 className="gradient-text text-3xl font-extrabold leading-tight md:text-4xl lg:text-5xl">
+              Limited Resources, Unlimited Impact with Multimodal AI Models
+            </h1>
+            <p className="text-foreground/80 text-sm leading-relaxed sm:text-base">
+              AI foundation models are increasingly dominating various academic
+              and industrial fields, yet the R&amp;D of related technologies is
+              controlled by limited institutions capable of managing extensive
+              computational and data resources. To counter this dominance, there
+              is a critical need for technologies that can develop practical AI
+              foundation models using the standard computational and data
+              resources. Our community (LIMIT.Community) and the international
+              lab (LIMIT.Lab) therefore aim to put in place exactly those
+              technologies that permit the construction of {'{'}Vision,
+              Vision-Language, Multimodal{'}'} AI foundational models even when
+              compute and data are limited. As of 2025, LIMIT.Lab is composed
+              primarily of international research teams from Japan, UK, and
+              Germany.
+            </p>
+            <div className="flex flex-col gap-2 pt-1">
+              <h2 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                Upcoming Events
+              </h2>
+              <div className="flex flex-wrap gap-3">
+                <Button
+                  className="h-auto rounded-xl px-5 py-2.5 text-sm font-semibold shadow-md transition-all hover:-translate-y-0.5 hover:shadow-lg"
+                  size="sm"
+                  asChild
+                >
+                  <Link
+                    href="https://cvpr2026-vgi-workshop.limitlab.xyz"
+                    target="_blank"
+                  >
+                    <span className="tracking-wide">CVPR 2026 VGI</span>
+                    <HiCursorClick className="size-4" />
+                  </Link>
+                </Button>
+                <Button
+                  className="h-auto rounded-xl px-5 py-2.5 text-sm font-semibold shadow-md transition-all hover:-translate-y-0.5 hover:shadow-lg"
+                  size="sm"
+                  asChild
+                >
+                  <Link
+                    href="https://cvpr2026-bigmac-workshop.limitlab.xyz"
+                    target="_blank"
+                  >
+                    <span className="tracking-wide">CVPR 2026 BigMAC</span>
+                    <HiCursorClick className="size-4" />
+                  </Link>
+                </Button>
+              </div>
+            </div>
           </div>
         </div>
-        <div className="flex justify-center md:justify-start">
-          <VisualAtomDesign />
-        </div>
-      </div>
+      </section>
 
       {/* Recent News */}
-      <div className="relative flex w-full max-w-[1000px] animate-slide-in-right flex-col-reverse items-center gap-6 px-4 py-8 before:absolute before:inset-y-0 before:-right-full before:z-0 before:block before:w-[200%] before:rounded-l-3xl before:border before:border-block-border sm:px-8 sm:py-10 md:flex-row md:items-center md:gap-8 md:px-12 md:py-14 lg:gap-14 lg:px-20">
-        <div className="flex size-auto min-w-[320px] justify-center md:justify-start">
-          <PaperOceanDesign />
-        </div>
-        <div className="flex w-full animate-fade-in-top flex-col items-start gap-3 animate-delay-700 animate-duration-500">
-          <h1 className="mb-2 text-2xl font-semibold leading-7 tracking-wider text-foreground shadow-background drop-shadow-md sm:text-2xl md:text-3xl md:leading-8">
+      <section id="news" className="space-y-8">
+        <div className="flex flex-col items-start gap-3">
+          <h2 className="text-3xl font-bold tracking-tight md:text-4xl">
             Recent News
-          </h1>
-          <div className="max-h-[400px] space-y-4 overflow-y-auto pr-2 sm:max-h-[500px]">
+          </h2>
+          <div className="section-accent" />
+        </div>
+
+        <div className="grid gap-8 lg:grid-cols-[2fr_3fr] lg:items-start">
+          {/* Paper Ocean decorative element */}
+          <div className="glass card-hover overflow-hidden rounded-3xl p-3 shadow-sm">
+            <div className="flex justify-center">
+              <PaperOceanDesign />
+            </div>
+            <p className="px-2 pb-2 pt-3 text-xs leading-relaxed text-muted-foreground">
+              A glimpse into the ocean of papers we navigate — hover to explore.
+            </p>
+          </div>
+
+          {/* News list */}
+          <div className="glass max-h-[520px] space-y-4 overflow-y-auto rounded-3xl p-4 pr-3 shadow-sm sm:p-6">
             {newsItems.map((item, index) => (
-              <div key={index} className="flex flex-col gap-1">
-                <div className="flex items-center gap-2">
+              <div
+                key={index}
+                className="border-border/40 bg-background/40 hover:bg-background/70 rounded-xl border p-4 transition-colors"
+              >
+                <div className="flex flex-wrap items-center gap-2">
                   <span
-                    className={`${geistMono.className} text-xs font-semibold text-muted-foreground sm:text-sm`}
+                    className={`${geistMono.className} text-xs font-semibold text-muted-foreground`}
                   >
                     {item.date}
                   </span>
@@ -135,7 +162,7 @@ export default function TopPage() {
                     </span>
                   )}
                 </div>
-                <div className="text-sm sm:text-base">
+                <div className="mt-1.5 text-sm leading-relaxed sm:text-base">
                   {item.content.map((part, partIndex) =>
                     typeof part === 'string' ? (
                       <span key={partIndex}>{part}</span>
@@ -144,7 +171,7 @@ export default function TopPage() {
                         key={partIndex}
                         href={part.url}
                         target="_blank"
-                        className="underline"
+                        className="font-medium text-brand-blue-11 underline decoration-brand-blue-a5 underline-offset-4 transition-colors hover:text-brand-blue-12 hover:decoration-brand-blue-9"
                       >
                         {part.text}
                       </Link>
@@ -155,70 +182,90 @@ export default function TopPage() {
             ))}
           </div>
         </div>
-      </div>
+      </section>
 
-      {/* Member Information */}
-      <div className="mb-8 flex w-full max-w-[1000px] animate-fade-in-top flex-col items-center gap-3 rounded-3xl border border-block-border px-4 py-8 animate-delay-700 animate-duration-500 sm:mb-12 sm:px-8 sm:py-10 md:mb-16 md:px-12 md:py-14 lg:px-20">
-        <h1 className="mb-2 text-2xl font-semibold leading-7 tracking-wider text-foreground shadow-background drop-shadow-md sm:text-2xl md:text-3xl md:leading-8">
-          Our Members
-        </h1>
-        <div className="flex w-full flex-col items-center">
-          <div className="grid grid-cols-1 gap-4 xs:grid-cols-2 sm:gap-6 md:grid-cols-3 xl:grid-cols-4">
-            {members.map((member, idx) => (
-              <Card
-                key={idx}
-                className="pb-1 pt-4 shadow backdrop-blur-xs sm:pt-5"
-              >
-                <CardContent>
-                  <div className="flex justify-center">
-                    <Avatar className="size-20 sm:size-24">
-                      <AvatarImage src={member.photoUrl} alt={member.name} />
-                      <AvatarFallback>?</AvatarFallback>
-                    </Avatar>
-                  </div>
-                  <div className="space-y-1 pt-2 text-center sm:pt-3">
-                    <div className="text-sm font-semibold sm:text-base">
-                      {member.name}
-                    </div>
-                    <div className="text-xs text-muted-foreground sm:text-sm">
-                      {member.affiliation}
-                    </div>
-                  </div>
-                  <div className="flex justify-center pt-2 sm:pt-3">
-                    <div className="flex gap-3 text-icon-fill sm:gap-4">
-                      {member.homePageUrl && (
-                        <Link href={member.homePageUrl} target="_blank">
-                          <RiGlobalLine className="size-4 hover:animate-scale-up-md hover:text-icon-accent hover:animate-duration-200 sm:size-5" />
-                        </Link>
-                      )}
-                      {member.googleScholarUrl && (
-                        <Link href={member.googleScholarUrl} target="_blank">
-                          <SiGooglescholar className="size-4 hover:animate-scale-up-md hover:text-icon-accent hover:animate-duration-200 sm:size-5" />
-                        </Link>
-                      )}
-                      {member.githubUrl && (
-                        <Link href={member.githubUrl} target="_blank">
-                          <RxGithubLogo className="size-4 hover:animate-scale-up-md hover:text-icon-accent hover:animate-duration-200 sm:size-5" />
-                        </Link>
-                      )}
-                      {member.XUrl && (
-                        <Link href={member.XUrl} target="_blank">
-                          <PiXLogo className="size-4 hover:animate-scale-up-md hover:text-icon-accent hover:animate-duration-200 sm:size-5" />
-                        </Link>
-                      )}
-                      {member.linkedinUrl && (
-                        <Link href={member.linkedinUrl} target="_blank">
-                          <RxLinkedinLogo className="size-4 hover:animate-scale-up-md hover:text-icon-accent hover:animate-duration-200 sm:size-5" />
-                        </Link>
-                      )}
-                    </div>
-                  </div>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
+      {/* Members */}
+      <section id="members" className="space-y-8">
+        <div className="flex flex-col items-start gap-3">
+          <h2 className="text-3xl font-bold tracking-tight md:text-4xl">
+            Our Members
+          </h2>
+          <div className="section-accent" />
+          <p className="text-sm text-muted-foreground sm:text-base">
+            An international team of researchers across Japan, UK, Germany, and
+            beyond.
+          </p>
         </div>
-      </div>
+
+        <div className="grid grid-cols-1 gap-4 xs:grid-cols-2 sm:gap-6 md:grid-cols-3 xl:grid-cols-4">
+          {members.map((member, idx) => (
+            <div
+              key={idx}
+              className="glass card-hover group flex flex-col items-center gap-3 rounded-2xl p-5 text-center"
+            >
+              <Avatar className="ring-border/50 size-20 ring-2 transition-all group-hover:ring-brand-blue-a8 sm:size-24">
+                <AvatarImage src={member.photoUrl} alt={member.name} />
+                <AvatarFallback>?</AvatarFallback>
+              </Avatar>
+              <div className="space-y-0.5">
+                <div className="text-sm font-semibold leading-tight sm:text-base">
+                  {member.name}
+                </div>
+                <div className="text-xs text-muted-foreground sm:text-sm">
+                  {member.affiliation}
+                </div>
+              </div>
+              <div className="mt-1 flex gap-3 text-icon-fill">
+                {member.homePageUrl && (
+                  <Link
+                    href={member.homePageUrl}
+                    target="_blank"
+                    aria-label={`${member.name} homepage`}
+                  >
+                    <RiGlobalLine className="size-4 transition-all hover:scale-110 hover:text-icon-accent sm:size-5" />
+                  </Link>
+                )}
+                {member.googleScholarUrl && (
+                  <Link
+                    href={member.googleScholarUrl}
+                    target="_blank"
+                    aria-label={`${member.name} Google Scholar`}
+                  >
+                    <SiGooglescholar className="size-4 transition-all hover:scale-110 hover:text-icon-accent sm:size-5" />
+                  </Link>
+                )}
+                {member.githubUrl && (
+                  <Link
+                    href={member.githubUrl}
+                    target="_blank"
+                    aria-label={`${member.name} GitHub`}
+                  >
+                    <RxGithubLogo className="size-4 transition-all hover:scale-110 hover:text-icon-accent sm:size-5" />
+                  </Link>
+                )}
+                {member.XUrl && (
+                  <Link
+                    href={member.XUrl}
+                    target="_blank"
+                    aria-label={`${member.name} X`}
+                  >
+                    <PiXLogo className="size-4 transition-all hover:scale-110 hover:text-icon-accent sm:size-5" />
+                  </Link>
+                )}
+                {member.linkedinUrl && (
+                  <Link
+                    href={member.linkedinUrl}
+                    target="_blank"
+                    aria-label={`${member.name} LinkedIn`}
+                  >
+                    <RxLinkedinLogo className="size-4 transition-all hover:scale-110 hover:text-icon-accent sm:size-5" />
+                  </Link>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
     </div>
   )
 }

--- a/src/app/(homepage)/publications/page.tsx
+++ b/src/app/(homepage)/publications/page.tsx
@@ -5,12 +5,10 @@ import Image from 'next/image'
 import { RxFile, RxGithubLogo } from 'react-icons/rx'
 import { RiGlobalLine } from 'react-icons/ri'
 import Link from 'next/link'
-import { Separator } from '@radix-ui/react-separator'
 
 import { samplePublications } from '@/data/publicationPageData'
 
 // shadcn/ui components
-import { Card, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import {
   Select,
@@ -42,181 +40,180 @@ export default function PublicationsPage() {
       const fieldMatch = fieldFilter === 'all' || pub.field === fieldFilter
       return confMatch && yearMatch && fieldMatch
     })
-    .sort((a, b) => b.id - a.id) // Sort by ID in descending order to add new publications at the top
+    .sort((a, b) => b.id - a.id)
 
   return (
-    <div className="flex w-11/12 flex-1 flex-col items-center gap-6 py-8 sm:w-4/5 sm:gap-8">
-      {/* Page Title */}
-      <div className="w-full max-w-[1000px] text-center">
-        <h1 className="mb-2 text-2xl font-semibold leading-7 tracking-wider text-foreground shadow-background drop-shadow-md sm:text-3xl md:text-4xl md:leading-10">
+    <div className="container mx-auto w-full max-w-6xl space-y-12 px-6 py-12 md:px-8">
+      {/* Page header */}
+      <header className="fade-in-up flex flex-col items-start gap-3">
+        <h1 className="gradient-text text-4xl font-extrabold tracking-tight md:text-5xl">
           Publications
         </h1>
-        <p className="mx-auto mt-4 max-w-2xl text-sm text-sub sm:text-base">
+        <div className="section-accent" />
+        <p className="max-w-2xl text-sm text-muted-foreground sm:text-base">
           Explore our latest research publications, showcasing advancements in
           various fields. Use the filters below to find publications by
           conference, year, or field of study.
         </p>
-      </div>
-      <div className="flex w-full max-w-[1000px] flex-col items-center gap-5 rounded-3xl border border-block-border px-4 pb-8 pt-6 sm:gap-7 sm:px-8 sm:pb-12 sm:pt-8 md:px-10 md:pb-16 md:pt-10">
-        {/* Filters */}
-        <div className="flex w-full flex-wrap gap-3 self-end sm:flex-nowrap sm:gap-4 sm:self-end">
-          {/* Conference Filter */}
-          <div className="flex w-full flex-col items-start gap-1 sm:w-auto sm:gap-2">
-            <div className="text-sm font-semibold sm:text-base">Conference</div>
-            <Select
-              value={conferenceFilter}
-              onValueChange={(val) => setConferenceFilter(val)}
-            >
-              <SelectTrigger className="w-full sm:w-[100px]">
-                <SelectValue placeholder="Conference" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">All</SelectItem>
-                {conferences.map((conf) => (
-                  <SelectItem key={conf} value={conf}>
-                    {conf}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
+      </header>
 
-          {/* Year Filter */}
-          <div className="flex w-full flex-col items-start gap-1 sm:w-auto sm:gap-2">
-            <div className="text-sm font-semibold sm:text-base">Year</div>
-            <Select
-              value={yearFilter}
-              onValueChange={(val) => setYearFilter(val)}
-            >
-              <SelectTrigger className="w-full sm:w-[100px]">
-                <SelectValue placeholder="Year" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">All</SelectItem>
-                {years.map((y) => (
-                  <SelectItem key={y} value={String(y)}>
-                    {y}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-
-          {/* Field Filter */}
-          <div className="flex w-full flex-col items-start gap-1 sm:w-auto sm:gap-2">
-            <div className="text-sm font-semibold sm:text-base">Field</div>
-            <Select
-              value={fieldFilter}
-              onValueChange={(val) => setFieldFilter(val)}
-            >
-              <SelectTrigger className="w-full sm:w-[180px]">
-                <SelectValue placeholder="Field" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">All</SelectItem>
-                {fields.map((f) => (
-                  <SelectItem key={f} value={f}>
-                    {f}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
+      {/* Filters */}
+      <div className="glass flex flex-wrap items-end justify-end gap-3 rounded-2xl p-4 shadow-sm sm:gap-4 sm:p-5">
+        <div className="flex w-full flex-col items-start gap-1.5 sm:w-auto">
+          <label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            Conference
+          </label>
+          <Select
+            value={conferenceFilter}
+            onValueChange={(val) => setConferenceFilter(val)}
+          >
+            <SelectTrigger className="w-full sm:w-[140px]">
+              <SelectValue placeholder="Conference" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All</SelectItem>
+              {conferences.map((conf) => (
+                <SelectItem key={conf} value={conf}>
+                  {conf}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
 
-        {/* Publication List */}
-        <div className="flex w-full flex-col items-center gap-4">
-          {filteredPublications.map((pub) => (
-            <Card
-              key={pub.id}
-              className="w-full place-content-center p-3 sm:p-4"
-            >
-              <CardContent className="flex h-full flex-col items-center gap-4 p-0 md:flex-row md:items-start">
-                {/* Publication Image */}
-                <div className="w-full overflow-hidden rounded-md md:w-1/3 md:min-w-60 lg:min-w-80">
-                  <AspectRatio ratio={16 / 9}>
-                    <Image
-                      src={pub.imageUrl}
-                      alt={pub.title}
-                      fill
-                      className="rounded-md object-cover"
-                      priority={pub.id === 1}
-                    />
-                  </AspectRatio>
-                </div>
+        <div className="flex w-full flex-col items-start gap-1.5 sm:w-auto">
+          <label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            Year
+          </label>
+          <Select
+            value={yearFilter}
+            onValueChange={(val) => setYearFilter(val)}
+          >
+            <SelectTrigger className="w-full sm:w-[120px]">
+              <SelectValue placeholder="Year" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All</SelectItem>
+              {years.map((y) => (
+                <SelectItem key={y} value={String(y)}>
+                  {y}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
 
-                {/* Publication Details */}
-                <div className="flex w-full flex-1 flex-col items-start justify-between gap-3 py-1 md:h-full md:py-2">
-                  {/* Tags */}
-                  <div className="flex w-fit gap-2 self-end">
-                    <Badge
-                      variant="conference"
-                      className="text-xs font-medium sm:text-sm"
-                    >
+        <div className="flex w-full flex-col items-start gap-1.5 sm:w-auto">
+          <label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            Field
+          </label>
+          <Select
+            value={fieldFilter}
+            onValueChange={(val) => setFieldFilter(val)}
+          >
+            <SelectTrigger className="w-full sm:w-[200px]">
+              <SelectValue placeholder="Field" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All</SelectItem>
+              {fields.map((f) => (
+                <SelectItem key={f} value={f}>
+                  {f}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {/* Publication list */}
+      <div className="space-y-5">
+        {filteredPublications.map((pub) => (
+          <article
+            key={pub.id}
+            className="glass card-hover overflow-hidden rounded-2xl p-4 shadow-sm sm:p-5"
+          >
+            <div className="flex h-full flex-col items-stretch gap-5 md:flex-row md:items-start">
+              {/* Image */}
+              <div className="w-full overflow-hidden rounded-xl md:w-1/3 md:min-w-60 lg:min-w-72">
+                <AspectRatio ratio={16 / 9}>
+                  <Image
+                    src={pub.imageUrl}
+                    alt={pub.title}
+                    fill
+                    className="rounded-xl object-cover"
+                    priority={pub.id === 1}
+                  />
+                </AspectRatio>
+              </div>
+
+              {/* Details */}
+              <div className="flex flex-1 flex-col justify-between gap-3 py-1">
+                <div className="space-y-3">
+                  <div className="flex flex-wrap gap-2">
+                    <Badge variant="conference" className="text-xs font-medium">
                       {pub.conference}
                     </Badge>
-                    <Badge
-                      variant="year"
-                      className="text-xs font-medium sm:text-sm"
-                    >
+                    <Badge variant="year" className="text-xs font-medium">
                       {pub.year}
+                    </Badge>
+                    <Badge variant="type" className="text-xs font-medium">
+                      {pub.field}
                     </Badge>
                   </div>
 
-                  {/* Title and Authors */}
-                  <div className="flex w-full flex-col gap-1">
-                    <div className="flex w-full flex-col gap-1">
-                      <h2 className="w-full text-base font-semibold leading-5 sm:text-lg sm:leading-6">
-                        {pub.title}
-                      </h2>
-                      <Separator
-                        orientation="horizontal"
-                        className="h-px w-full bg-underline"
-                      />
-                    </div>
-                    <div className="w-full text-xs text-sub">
-                      Authors: {pub.authors}
-                    </div>
-                  </div>
+                  <h2 className="text-base font-semibold leading-snug tracking-tight sm:text-lg md:text-xl">
+                    {pub.title}
+                  </h2>
 
-                  {/* Action Buttons */}
-                  <div className="flex w-full flex-wrap gap-2 sm:flex-nowrap sm:gap-4">
+                  <div className="text-xs leading-relaxed text-muted-foreground sm:text-sm">
+                    {pub.authors}
+                  </div>
+                </div>
+
+                {/* Action buttons */}
+                <div className="flex flex-wrap gap-2 pt-2 sm:gap-3">
+                  {pub.projectPageUrl && (
                     <Link
                       href={pub.projectPageUrl}
                       target="_blank"
-                      className="flex h-auto items-center gap-1 rounded-md border border-button-project bg-button-project px-2 py-1.5 text-button-project-foreground hover:bg-button-project-hovered hover:text-button-project-foreground-hovered sm:gap-2 sm:px-3 sm:py-2"
+                      className="flex items-center gap-1.5 rounded-lg border border-button-project bg-button-project px-3 py-1.5 text-button-project-foreground transition-colors hover:bg-button-project-hovered hover:text-button-project-foreground-hovered sm:gap-2"
                     >
-                      <RiGlobalLine className="size-4 sm:size-5" />
+                      <RiGlobalLine className="size-4" />
                       <span className="text-xs font-medium sm:text-sm">
-                        Project Page
+                        Project
                       </span>
                     </Link>
+                  )}
+                  {pub.pdfFileUrl && (
                     <Link
                       href={pub.pdfFileUrl}
                       target="_blank"
-                      className="flex h-auto items-center gap-1 rounded-md border border-button-pdf bg-button-pdf px-2 py-1.5 text-button-pdf-foreground hover:bg-button-pdf-hovered hover:text-button-pdf-foreground-hovered sm:gap-2 sm:px-3 sm:py-2"
+                      className="flex items-center gap-1.5 rounded-lg border border-button-pdf bg-button-pdf px-3 py-1.5 text-button-pdf-foreground transition-colors hover:bg-button-pdf-hovered hover:text-button-pdf-foreground-hovered sm:gap-2"
                     >
-                      <RxFile className="size-4 sm:size-5" />
+                      <RxFile className="size-4" />
                       <span className="text-xs font-medium sm:text-sm">
                         PDF
                       </span>
                     </Link>
+                  )}
+                  {pub.githubUrl && (
                     <Link
                       href={pub.githubUrl}
                       target="_blank"
-                      className="flex h-auto items-center gap-1 rounded-md border border-button-github bg-button-github px-2 py-1.5 text-button-github-foreground hover:bg-button-github-hovered hover:text-button-github-foreground-hovered sm:gap-2 sm:px-3 sm:py-2"
+                      className="flex items-center gap-1.5 rounded-lg border border-button-github bg-button-github px-3 py-1.5 text-button-github-foreground transition-colors hover:bg-button-github-hovered hover:text-button-github-foreground-hovered sm:gap-2"
                     >
-                      <RxGithubLogo className="size-4 sm:size-5" />
+                      <RxGithubLogo className="size-4" />
                       <span className="text-xs font-medium sm:text-sm">
                         GitHub
                       </span>
                     </Link>
-                  </div>
+                  )}
                 </div>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
+              </div>
+            </div>
+          </article>
+        ))}
       </div>
     </div>
   )

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -562,4 +562,103 @@
   body {
     @apply bg-background text-foreground;
   }
+
+  /* Sticky header offset for in-page anchors */
+  section[id] {
+    scroll-margin-top: 6rem;
+  }
+
+  /* Modernized heading scale — tighter tracking, larger sizes */
+  h1, h2, h3, h4, h5, h6 {
+    @apply font-bold tracking-tight;
+  }
+  h1 {
+    @apply text-4xl md:text-5xl lg:text-6xl;
+    letter-spacing: -0.02em;
+  }
+  h2 {
+    @apply text-3xl md:text-4xl lg:text-5xl;
+    letter-spacing: -0.015em;
+  }
+  h3 {
+    @apply text-2xl md:text-3xl;
+    letter-spacing: -0.01em;
+  }
+}
+
+@layer utilities {
+  /* Glassmorphism surfaces (color-mix lets us blend the themed background
+     with transparency without relying on Tailwind opacity modifiers). */
+  .glass {
+    background-color: color-mix(in srgb, var(--background) 70%, transparent);
+    backdrop-filter: blur(24px);
+    -webkit-backdrop-filter: blur(24px);
+    border: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
+  }
+  .glass-strong {
+    background-color: color-mix(in srgb, var(--background) 88%, transparent);
+    backdrop-filter: blur(40px);
+    -webkit-backdrop-filter: blur(40px);
+    border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
+  }
+
+  /* Card hover lift */
+  .card-hover {
+    transition: transform 0.3s ease-out, box-shadow 0.3s ease-out;
+  }
+  .card-hover:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 20px 25px -5px var(--blue-a4), 0 8px 10px -6px var(--blue-a3);
+  }
+
+  /* Gradient text — used on hero h1 */
+  .gradient-text {
+    @apply bg-clip-text text-transparent;
+    background-image: linear-gradient(135deg, var(--blue-12) 0%, var(--blue-11) 60%, var(--blue-9) 100%);
+  }
+  .dark .gradient-text {
+    background-image: linear-gradient(135deg, var(--blue-12) 0%, var(--blue-11) 50%, var(--blue-9) 100%);
+  }
+
+  /* Soft radial gradient backdrop for hero areas */
+  .gradient-mesh {
+    background-image:
+      radial-gradient(at 0% 0%, var(--blue-9) 0%, transparent 50%),
+      radial-gradient(at 100% 100%, var(--purple-9) 0%, transparent 50%);
+    opacity: 0.07;
+    pointer-events: none;
+  }
+  .dark .gradient-mesh {
+    opacity: 0.12;
+  }
+
+  /* Section accent bar — used after h2 headers */
+  .section-accent {
+    @apply h-1 w-20 rounded-full;
+    background-image: linear-gradient(90deg, var(--blue-9), var(--blue-a4));
+  }
+
+  /* Fade-in-up entrance animation */
+  @keyframes fadeInUp {
+    from {
+      opacity: 0;
+      transform: translateY(20px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+  .fade-in-up {
+    animation: fadeInUp 0.6s ease-out both;
+  }
+
+  /* Hide scrollbar (carousel-friendly) */
+  .scrollbar-hide {
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+  }
+  .scrollbar-hide::-webkit-scrollbar {
+    display: none;
+  }
 }

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -4,9 +4,8 @@ import { useTheme } from 'next-themes'
 import Image from 'next/image'
 import { useEffect, useState } from 'react'
 import { PiXLogo } from 'react-icons/pi'
-import { RxGithubLogo, RxCross1 } from 'react-icons/rx'
+import { RxGithubLogo } from 'react-icons/rx'
 import { RiGlobalLine } from 'react-icons/ri'
-import { SiGitconnected } from 'react-icons/si'
 import Link from 'next/link'
 import blackAlumniLogo from '../../public/alumni-logo-with-wide-black.png'
 import whiteAlumniLogo from '../../public/alumni-logo-with-wide-white.png'
@@ -15,14 +14,39 @@ import whiteCCLogo from '../../public/cvpaper-logo-white.png'
 import whiteLimitLabLogoWide from '../../public/limitlab-logo-white-wide.png'
 import blackLimitLabLogoWide from '../../public/limitlab-logo-black-wide.png'
 
-// shadcn/ui components
-import { Separator } from '@/components/ui/separator'
+const pageLinks = [
+  { label: 'Top', href: '/' },
+  { label: 'Publications', href: '/publications' },
+  { label: 'Events & Reports', href: '/events-reports' },
+  { label: 'Contact', href: '/contact' },
+]
+
+const workshopLinks = [
+  {
+    label: 'ECCV 2026 LIMIT',
+    href: 'https://eccv2026-limit-workshop.limitlab.xyz',
+  },
+  {
+    label: 'CVPR 2026 VGI',
+    href: 'https://cvpr2026-vgi-workshop.limitlab.xyz',
+  },
+  {
+    label: 'CVPR 2026 BigMAC',
+    href: 'https://cvpr2026-bigmac-workshop.limitlab.xyz',
+  },
+  {
+    label: 'ICCV 2025 LIMIT',
+    href: 'https://iccv2025-limit-workshop.limitlab.xyz',
+  },
+  {
+    label: 'ICCV 2025 FOUND',
+    href: 'https://iccv2025-found-workshop.limitlab.xyz',
+  },
+]
 
 export function Footer() {
   const { theme } = useTheme()
   const [isDarkMode, setIsDarkMode] = useState(false)
-  const [hasHoverdAlumni, setHasHoveredAlumni] = useState(false)
-  const [hasHoverdCC, setHasHoveredCC] = useState(false)
 
   useEffect(() => {
     if (theme) {
@@ -31,132 +55,141 @@ export function Footer() {
   }, [theme])
 
   return (
-    <div className="flex min-h-44 w-full justify-center bg-secondary p-4 py-6 text-secondary-foreground sm:p-6">
-      <div className="flex w-full max-w-[1500px] flex-col items-center justify-between gap-6 sm:gap-4 md:flex-row">
-        {/* Placeholder logo */}
-        <div className="flex flex-col items-center gap-1 md:ml-4 md:items-center lg:ml-10">
-          <div className="flex items-center space-x-2">
+    <footer className="border-border/50 bg-background/60 mt-24 flex w-full justify-center border-t backdrop-blur-xl">
+      <div className="flex w-full max-w-[1500px] flex-col gap-12 px-6 py-12 md:py-16 lg:px-10">
+        {/* Top grid: brand + columns */}
+        <div className="grid gap-10 md:grid-cols-2 lg:grid-cols-4">
+          {/* Brand */}
+          <div className="flex flex-col items-start gap-4">
             <Image
-              alt="limit.lab logo"
-              className="h-20 w-auto sm:h-20"
-              priority={true}
+              alt="LIMIT.Lab logo"
+              className="h-16 w-auto"
+              priority={false}
               src={isDarkMode ? whiteLimitLabLogoWide : blackLimitLabLogoWide}
             />
+            <p className="text-sm leading-relaxed text-muted-foreground">
+              Limited resources, unlimited impact with multimodal AI foundation
+              models. An international research collective.
+            </p>
           </div>
-          <div className="text-xs text-sub">
-            © 2025 LIMIT.Lab. All rights reserved.
+
+          {/* Pages */}
+          <div className="flex flex-col gap-3">
+            <h3 className="text-base font-semibold tracking-tight text-foreground">
+              Pages
+            </h3>
+            <div className="flex flex-col gap-2">
+              {pageLinks.map((item) => (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  className="w-fit text-sm text-muted-foreground transition-colors hover:text-foreground"
+                >
+                  {item.label}
+                </Link>
+              ))}
+            </div>
+          </div>
+
+          {/* Workshops */}
+          <div className="flex flex-col gap-3">
+            <h3 className="text-base font-semibold tracking-tight text-foreground">
+              Workshops
+            </h3>
+            <div className="flex flex-col gap-2">
+              {workshopLinks.map((item) => (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  target="_blank"
+                  className="w-fit text-sm text-muted-foreground transition-colors hover:text-foreground"
+                >
+                  {item.label}
+                </Link>
+              ))}
+            </div>
+          </div>
+
+          {/* Supported by */}
+          <div className="flex flex-col gap-3">
+            <h3 className="text-base font-semibold tracking-tight text-foreground">
+              Supported by
+            </h3>
+            <div className="flex flex-col gap-5">
+              <div className="flex flex-col gap-2">
+                <Image
+                  alt="cvpaper.challenge alumni logo"
+                  className="h-10 w-auto"
+                  priority={false}
+                  src={isDarkMode ? whiteAlumniLogo : blackAlumniLogo}
+                />
+                <div className="flex items-center gap-3 text-icon-fill">
+                  <Link
+                    href="https://github.com/cvpaperchallenge-alumni"
+                    target="_blank"
+                    aria-label="alumni GitHub"
+                  >
+                    <RxGithubLogo className="size-4 transition-colors hover:text-icon-accent" />
+                  </Link>
+                  <Link
+                    href="https://twitter.com/cvpcalumni"
+                    target="_blank"
+                    aria-label="alumni X"
+                  >
+                    <PiXLogo className="size-4 transition-colors hover:text-icon-accent" />
+                  </Link>
+                  <Link
+                    href="https://note.com/gatheluck/n/nc469f2f35426"
+                    target="_blank"
+                    aria-label="alumni website"
+                  >
+                    <RiGlobalLine className="size-4 transition-colors hover:text-icon-accent" />
+                  </Link>
+                </div>
+              </div>
+              <div className="flex flex-col gap-2">
+                <Image
+                  alt="cvpaper.challenge logo"
+                  className="h-10 w-auto"
+                  priority={false}
+                  src={isDarkMode ? whiteCCLogo : blackCCLogo}
+                />
+                <div className="flex items-center gap-3 text-icon-fill">
+                  <Link
+                    href="https://github.com/cvpaperchallenge"
+                    target="_blank"
+                    aria-label="cvpaper.challenge GitHub"
+                  >
+                    <RxGithubLogo className="size-4 transition-colors hover:text-icon-accent" />
+                  </Link>
+                  <Link
+                    href="https://x.com/CVpaperChalleng"
+                    target="_blank"
+                    aria-label="cvpaper.challenge X"
+                  >
+                    <PiXLogo className="size-4 transition-colors hover:text-icon-accent" />
+                  </Link>
+                  <Link
+                    href="https://xpaperchallenge.org/cv/"
+                    target="_blank"
+                    aria-label="cvpaper.challenge website"
+                  >
+                    <RiGlobalLine className="size-4 transition-colors hover:text-icon-accent" />
+                  </Link>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
 
-        {/* Mobile view for supported by text */}
-        <div className="flex flex-col items-center gap-2 md:hidden">
-          <div className="text-xs">Supported by</div>
-          <div className="flex flex-col items-center gap-px">
-            <Link
-              href="https://github.com/cvpaperchallenge-alumni"
-              target="_blank"
-              className="flex gap-2 text-xs text-accent-foreground"
-            >
-              cvpaper.challenge alumni community
-            </Link>
-            <RxCross1 className="size-2" />
-            <Link
-              href="https://xpaperchallenge.org/cv/"
-              target="_blank"
-              className="flex gap-2 text-xs text-accent-foreground"
-            >
-              cvpaper.challenge
-            </Link>
+        {/* Bottom strip */}
+        <div className="border-border/40 flex flex-col items-center justify-between gap-3 border-t pt-6 text-xs text-muted-foreground md:flex-row">
+          <div>
+            © {new Date().getFullYear()} LIMIT.Lab. All rights reserved.
           </div>
-        </div>
-
-        {/* Desktop view with logos */}
-        <div className="hidden md:mr-4 md:flex md:flex-col md:items-start md:gap-0 lg:mr-10">
-          <div className="pl-2 text-xs">Supported by </div>
-          <div
-            className="flex items-center gap-4"
-            onMouseEnter={() => setHasHoveredAlumni(true)}
-          >
-            <div className="group flex flex-col items-center gap-2">
-              <Image
-                alt="alumni logo"
-                className="h-12 w-auto sm:h-16"
-                priority={true}
-                src={isDarkMode ? whiteAlumniLogo : blackAlumniLogo}
-              />
-              <div
-                className={
-                  'flex items-center gap-2 text-icon-fill group-hover:animate-fade-in-top ' +
-                  (hasHoverdAlumni ? 'animate-fade-out-top' : 'invisible')
-                }
-              >
-                <Link
-                  href="https://github.com/cvpaperchallenge-alumni"
-                  target="_blank"
-                >
-                  <RxGithubLogo className="size-5 hover:text-icon-accent" />
-                </Link>
-                <Separator
-                  orientation="vertical"
-                  className="h-5 bg-muted-foreground"
-                />
-                <Link href="https://twitter.com/cvpcalumni" target="_blank">
-                  <PiXLogo className="size-5 hover:text-icon-accent" />
-                </Link>
-                <Separator
-                  orientation="vertical"
-                  className="h-5 bg-muted-foreground"
-                />
-                <Link
-                  href="https://note.com/gatheluck/n/nc469f2f35426"
-                  target="_blank"
-                >
-                  <RiGlobalLine className="size-4 hover:text-icon-accent sm:size-5" />
-                </Link>
-              </div>
-            </div>
-            <SiGitconnected className="size-4 -translate-y-2 sm:size-5 sm:-translate-y-3" />
-            <div
-              className="group flex flex-col items-center gap-2"
-              onMouseEnter={() => setHasHoveredCC(true)}
-            >
-              <Image
-                alt="cvpaper challenge logo"
-                className="h-12 w-auto sm:h-16"
-                priority={true}
-                src={isDarkMode ? whiteCCLogo : blackCCLogo}
-              />
-              <div
-                className={
-                  'flex items-center gap-2 text-icon-fill group-hover:animate-fade-in-top ' +
-                  (hasHoverdCC ? 'animate-fade-out-top' : 'invisible')
-                }
-              >
-                <Link
-                  href="https://github.com/cvpaperchallenge"
-                  target="_blank"
-                >
-                  <RxGithubLogo className="size-4 hover:text-icon-accent sm:size-5" />
-                </Link>
-                <Separator
-                  orientation="vertical"
-                  className="h-4 bg-muted-foreground sm:h-5"
-                />
-                <Link href="https://x.com/CVpaperChalleng" target="_blank">
-                  <PiXLogo className="size-4 hover:text-icon-accent sm:size-5" />
-                </Link>
-                <Separator
-                  orientation="vertical"
-                  className="h-4 bg-muted-foreground sm:h-5"
-                />
-                <Link href="https://xpaperchallenge.org/cv/" target="_blank">
-                  <RiGlobalLine className="size-4 hover:text-icon-accent sm:size-5" />
-                </Link>
-              </div>
-            </div>
-          </div>
+          <div>Built by cvpaper.challenge Dev Team</div>
         </div>
       </div>
-    </div>
+    </footer>
   )
 }

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -6,8 +6,6 @@ import { useEffect, useState } from 'react'
 import { RxMoon, RxSun, RxHamburgerMenu } from 'react-icons/rx'
 import Link from 'next/link'
 import { useRouter, usePathname } from 'next/navigation'
-import blackVAMark from '../../public/visual_atoms_1_black.png'
-import whiteVAMark from '../../public/visual_atoms_1_white.png'
 import whiteLimitLabLogoWide from '../../public/limitlab-logo-white-wide.png'
 import blackLimitLabLogoWide from '../../public/limitlab-logo-black-wide.png'
 
@@ -25,15 +23,18 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 
+const navItems = [
+  { key: 'top', label: 'Top', href: '/' },
+  { key: 'publication', label: 'Publications', href: '/publications' },
+  { key: 'events-reports', label: 'Events & Reports', href: '/events-reports' },
+  { key: 'contact', label: 'Contact', href: '/contact' },
+] as const
+
 export function Header() {
   const { resolvedTheme, setTheme } = useTheme()
   const [isDarkMode, setIsDarkMode] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
-  const [page, setPage] = useState('top')
-  const [hasHoveredTop, setHasHoveredTop] = useState(false)
-  const [hasHoveredPublications, setHasHoveredPublications] = useState(false)
-  const [hasHoveredEventsReports, setHasHoveredEventsReports] = useState(false)
-  const [hasHoveredContact, setHasHoveredContact] = useState(false)
+  const [page, setPage] = useState<string>('top')
   const router = useRouter()
   const pathname = usePathname()
 
@@ -51,180 +52,51 @@ export function Header() {
     else if (pathname.startsWith('/contact')) setPage('contact')
   }, [pathname])
 
-  useEffect(() => {
-    function handleResize() {
-      if (window.innerWidth < 768) {
-        setHasHoveredTop(false)
-        setHasHoveredPublications(false)
-        setHasHoveredEventsReports(false)
-        setHasHoveredContact(false)
-      }
-    }
-    window.addEventListener('resize', handleResize)
-    return () => window.removeEventListener('resize', handleResize)
-  }, [])
-
   return (
-    <div className="flex h-auto min-h-20 w-full justify-center bg-secondary p-4 py-6 text-secondary-foreground sm:p-6">
-      <div className="flex w-full max-w-[1500px] flex-wrap justify-between">
-        {/* Logo + Title */}
-        <div className="flex justify-between gap-4 sm:gap-7">
-          <div className="flex items-center gap-2">
-            <Image
-              alt="limit.lab logo"
-              className="h-14 w-auto sm:h-14"
-              priority={true}
-              src={isDarkMode ? whiteLimitLabLogoWide : blackLimitLabLogoWide}
-            />
-            {/* <Separator
-              orientation="vertical"
-              className="ml-3 hidden bg-muted-foreground sm:ml-5 md:block"
-            /> */}
-          </div>
+    <header className="border-border/50 bg-background/70 fixed top-0 z-50 flex w-full justify-center border-b backdrop-blur-xl">
+      <div className="flex h-20 w-full max-w-[1500px] items-center justify-between px-4 sm:px-6 lg:px-8">
+        {/* Logo */}
+        <Link
+          href="/"
+          className="group flex items-center transition-transform hover:scale-[1.02]"
+        >
+          <Image
+            alt="LIMIT.Lab logo"
+            className="h-12 w-auto sm:h-14"
+            priority={true}
+            src={isDarkMode ? whiteLimitLabLogoWide : blackLimitLabLogoWide}
+          />
+        </Link>
 
-          {/* Navigation Links */}
-          <div className="hidden items-center justify-between space-x-5 md:flex">
-            <Button
-              variant="link"
-              asChild
-              className="group pl-0.5 font-semibold hover:animate-pulsate-fwd hover:no-underline"
-            >
+        {/* Desktop Nav */}
+        <nav className="hidden items-center gap-1 md:flex">
+          {navItems.map((item) => {
+            const isActive = page === item.key
+            return (
               <Link
-                href="/"
-                onMouseEnter={() => setHasHoveredTop(true)}
-                onMouseLeave={() => {}}
+                key={item.key}
+                href={item.href}
+                className={
+                  'rounded-lg px-4 py-2 text-sm transition-colors ' +
+                  (isActive
+                    ? 'bg-brand-blue-a4 font-semibold text-brand-blue-11'
+                    : 'text-foreground/70 font-medium hover:bg-brand-blue-a3 hover:text-foreground')
+                }
               >
-                <Image
-                  alt="VA mark"
-                  src={isDarkMode ? whiteVAMark : blackVAMark}
-                  width={32}
-                  height={32}
-                  className={
-                    `group-hover:animate-rotate-in-center ` +
-                    (hasHoveredTop ? 'animate-rotate-out-center' : 'invisible')
-                  }
-                />
-                <span
-                  className={
-                    page === 'top'
-                      ? 'text-accent-foreground'
-                      : 'text-sub group-hover:text-secondary-foreground'
-                  }
-                >
-                  Top
-                </span>
+                {item.label}
               </Link>
-            </Button>
-            <Button
-              variant="link"
-              asChild
-              className="group pl-0.5 font-semibold hover:animate-pulsate-fwd hover:no-underline"
-            >
-              <Link
-                href="/publications"
-                onMouseEnter={() => setHasHoveredPublications(true)}
-                onMouseLeave={() => {}}
-              >
-                <Image
-                  alt="VA mark"
-                  src={isDarkMode ? whiteVAMark : blackVAMark}
-                  width={32}
-                  height={32}
-                  className={
-                    `group-hover:animate-rotate-in-center ` +
-                    (hasHoveredPublications
-                      ? 'animate-rotate-out-center'
-                      : 'invisible')
-                  }
-                />
-                <span
-                  className={
-                    page === 'publication'
-                      ? 'text-accent-foreground'
-                      : 'text-sub group-hover:text-secondary-foreground'
-                  }
-                >
-                  Publications
-                </span>
-              </Link>
-            </Button>
-            <Button
-              variant="link"
-              asChild
-              className="group pl-0.5 font-semibold hover:animate-pulsate-fwd hover:no-underline"
-            >
-              <Link
-                href="/events-reports"
-                onMouseEnter={() => setHasHoveredEventsReports(true)}
-                onMouseLeave={() => {}}
-              >
-                <Image
-                  alt="VA mark"
-                  src={isDarkMode ? whiteVAMark : blackVAMark}
-                  width={32}
-                  height={32}
-                  className={
-                    `group-hover:animate-rotate-in-center ` +
-                    (hasHoveredEventsReports
-                      ? 'animate-rotate-out-center'
-                      : 'invisible')
-                  }
-                />
-                <span
-                  className={
-                    page === 'events-reports'
-                      ? 'text-accent-foreground'
-                      : 'text-sub group-hover:text-secondary-foreground'
-                  }
-                >
-                  Events &amp; Reports
-                </span>
-              </Link>
-            </Button>
-            <Button
-              variant="link"
-              asChild
-              className="group pl-0.5 font-semibold hover:animate-pulsate-fwd hover:no-underline"
-            >
-              <Link
-                href="/contact"
-                onMouseEnter={() => setHasHoveredContact(true)}
-                onMouseLeave={() => {}}
-              >
-                <Image
-                  alt="VA mark"
-                  src={isDarkMode ? whiteVAMark : blackVAMark}
-                  width={32}
-                  height={32}
-                  className={
-                    `group-hover:animate-rotate-in-center ` +
-                    (hasHoveredContact
-                      ? 'animate-rotate-out-center'
-                      : 'invisible')
-                  }
-                />
-                <span
-                  className={
-                    page === 'contact'
-                      ? 'text-accent-foreground'
-                      : 'text-sub group-hover:text-secondary-foreground'
-                  }
-                >
-                  Contact
-                </span>
-              </Link>
-            </Button>
-          </div>
-        </div>
+            )
+          })}
+        </nav>
 
-        {/* Theme Switcher */}
-        <div className="flex items-center space-x-4 sm:space-x-6">
+        {/* Right cluster: theme toggle + mobile menu */}
+        <div className="flex items-center gap-3 sm:gap-4">
           {isLoading ? (
-            <div className="flex w-16 flex-row justify-center sm:w-24">
+            <div className="flex w-16 justify-center">
               <Spinner size="small" />
             </div>
           ) : (
-            <div className="flex items-center space-x-2">
+            <div className="flex items-center gap-2">
               <RxSun className="size-3.5 text-sun-icon sm:size-4" />
               <Switch
                 id="theme-mode"
@@ -253,40 +125,22 @@ export function Header() {
                 <DropdownMenuLabel>Pages</DropdownMenuLabel>
                 <DropdownMenuSeparator />
                 <DropdownMenuRadioGroup value={page}>
-                  <DropdownMenuRadioItem
-                    value="top"
-                    isDarkMode={isDarkMode}
-                    onClick={() => router.push('/')}
-                  >
-                    Top
-                  </DropdownMenuRadioItem>
-                  <DropdownMenuRadioItem
-                    value="publication"
-                    isDarkMode={isDarkMode}
-                    onClick={() => router.push('/publications')}
-                  >
-                    Publications
-                  </DropdownMenuRadioItem>
-                  <DropdownMenuRadioItem
-                    value="events-reports"
-                    isDarkMode={isDarkMode}
-                    onClick={() => router.push('/events-reports')}
-                  >
-                    Events &amp; Reports
-                  </DropdownMenuRadioItem>
-                  <DropdownMenuRadioItem
-                    value="contact"
-                    isDarkMode={isDarkMode}
-                    onClick={() => router.push('/contact')}
-                  >
-                    Contact
-                  </DropdownMenuRadioItem>
+                  {navItems.map((item) => (
+                    <DropdownMenuRadioItem
+                      key={item.key}
+                      value={item.key}
+                      isDarkMode={isDarkMode}
+                      onClick={() => router.push(item.href)}
+                    >
+                      {item.label}
+                    </DropdownMenuRadioItem>
+                  ))}
                 </DropdownMenuRadioGroup>
               </DropdownMenuContent>
             </DropdownMenu>
           </div>
         </div>
       </div>
-    </div>
+    </header>
   )
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -156,6 +156,42 @@ const config = {
           '4': 'var(--chart-4)',
           '5': 'var(--chart-5)',
         },
+
+        // Brand palettes (Radix-style scales) — `brand-*` prefix avoids
+        // clobbering Tailwind's default blue/purple/gray scales used in
+        // existing tag-color classes like bg-blue-100.
+        'brand-blue': {
+          1: 'var(--blue-1)',
+          2: 'var(--blue-2)',
+          3: 'var(--blue-3)',
+          4: 'var(--blue-4)',
+          5: 'var(--blue-5)',
+          6: 'var(--blue-6)',
+          7: 'var(--blue-7)',
+          8: 'var(--blue-8)',
+          9: 'var(--blue-9)',
+          10: 'var(--blue-10)',
+          11: 'var(--blue-11)',
+          12: 'var(--blue-12)',
+          a1: 'var(--blue-a1)',
+          a2: 'var(--blue-a2)',
+          a3: 'var(--blue-a3)',
+          a4: 'var(--blue-a4)',
+          a5: 'var(--blue-a5)',
+          a6: 'var(--blue-a6)',
+          a7: 'var(--blue-a7)',
+          a8: 'var(--blue-a8)',
+          a9: 'var(--blue-a9)',
+          a10: 'var(--blue-a10)',
+          a11: 'var(--blue-a11)',
+          a12: 'var(--blue-a12)',
+        },
+        'brand-purple': {
+          1: 'var(--purple-1)',
+          9: 'var(--purple-9)',
+          11: 'var(--purple-11)',
+          12: 'var(--purple-12)',
+        },
       },
       screens: {
         xs: '350px'


### PR DESCRIPTION
## Summary

- Modernize the LIMIT.Lab homepage (Top / Publications / Events & Reports / Contact + shared Header / Footer) to align with the sibling project `ECCV2026LIMIT`
- Introduce glassmorphism (`.glass`, `.glass-strong`), gradient hero, and `brand-blue-*` / `brand-purple-*` color scales
- Preserve `VisualAtomDesign`, `PaperOceanDesign`, the animated grid, the dark-mode toggle, and all existing data + filter logic

### Key changes

| Area | Change |
|---|---|
| `globals.css` | Add `.glass` / `.glass-strong` / `.card-hover` / `.gradient-text` / `.gradient-mesh` / `.section-accent` / `.fade-in-up` / `.scrollbar-hide`. Re-define h1–h6 with `font-bold tracking-tight` and a larger scale. |
| `tailwind.config.ts` | Add `brand-blue-{1–12, a1–a12}` and `brand-purple-{1,9,11,12}` under `theme.extend.colors` (prefix used to avoid clobbering Tailwind's default `blue` / `purple`). |
| Header | Sticky + glass + blur. Nav simplified to 4 text links; active state uses a `bg-brand-blue-a4` blue pill. |
| Footer | 4-column layout (Brand / Pages / Workshops / Supported by) with a hard-coded workshop link list. |
| Top | Gradient h1 hero (atom on the left, copy on the right, switching at `lg:flex-row`), `PaperOceanDesign` wrapped in a glass card, members rendered as glass cards with an avatar-ring hover. |
| Publications / Events | Gradient header → glass filter strip → glass cards with `.card-hover`. Filter logic and sorting fully preserved. |
| Contact | Gradient h1 + `.glass-strong` panel + `.gradient-mesh` overlay. |

### Gotchas

- `.glass` uses `color-mix(in srgb, var(--background) 70%, transparent)`. `@apply bg-background/70` does not work because `--background` is a hex CSS var and Tailwind's opacity modifier does not apply.
- The news tag colors (`bg-blue-100` etc.) would break if `blue` / `purple` were added directly under `theme.extend.colors`, so the new palette is namespaced under the `brand-` prefix.

## Test plan

- [x] `npm run lint-check` passes
- [x] `npm run format-check` passes
- [x] `npm run build` prerenders all 8 pages
- [x] `npm run dev` returns 200 on all 4 routes
- [x] Visual QA in light/dark × 375 / 768 / 1280 px (hero h1 natural wrapping, header active state, atom glow all verified)
- [x] Reviewer-side visual check in a real browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)